### PR TITLE
SPI needs the docc-plugin installed to build the docs - this fixes that scenario

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ let previewDocs = ProcessInfo.processInfo.environment["SWIFT_PREVIEW_DOCS"] != n
 let enableAllTraitsExplicit = ProcessInfo.processInfo.environment["ENABLE_ALL_TRAITS"] != nil
 
 let enableAllTraits = spiGenerateDocs || previewDocs || enableAllTraitsExplicit
-let addDoccPlugin = previewDocs
+let addDoccPlugin = previewDocs || spiGenerateDocs
 
 traits.insert(
     .default(


### PR DESCRIPTION
adds in docc-plugin package when attempting to build docs for Swift Package Index