### PR TITLE
Use the general runner pool for PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,7 @@ jobs:
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
-      runner_pool: nightly
+      runner_pool: general
       build_scheme: swift-configuration-Package
       xcode_16_2_enabled: false
 


### PR DESCRIPTION
### Motivation

PRs should use the "general" macOS runner pool to ensure less waiting, "nightly" is meant to be for scheduled jobs only.

### Modifications

Updated from "nightly" to "general" pool for PRs.

### Result

Less waiting on macOS CI in PRs.

### Test Plan

N/A - this issue happened due to me copy-pasting the GH workflow YAML from the 'main' workflow.
