### PR TITLE
Fix up a secrets example

### DIFF
--- a/Sources/Configuration/Documentation.docc/Guides/Handling-secrets-correctly.md
+++ b/Sources/Configuration/Documentation.docc/Guides/Handling-secrets-correctly.md
@@ -96,8 +96,8 @@ let provider = JSONProvider(
 The following example asserts that none of the values returned from the provider are considered secret:
 
 ```swift
-let provider = InMemoryProvider(
-    values: ["app.name": "MyApp", "log.level": "info"],
+let provider = JSONProvider(
+    filePath: "/etc/config.json",
     secretsSpecifier: .none
 )
 ```


### PR DESCRIPTION

### Motivation

Fix up the docs - it incorrectly showed an example of using the secrets specifier with the InMemoryProvider, but that doesn't use a secrets specifier (secret values can be passed to it directly).

### Modifications

Replace InMemoryProvider with JSONProvider.

### Result

Corrected docs.

### Test Plan

N/A
