### PR TITLE
Update Package.swift

### DIFF
--- a/Examples/hello-world-cli-example/Package.swift
+++ b/Examples/hello-world-cli-example/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .macOS(.v15)
     ],
     dependencies: [
-        .package(path: "../..", traits: [.defaults, "CommandLineArgumentsSupport"])
+       .package(url: "https://github.com/apple/swift-configuration", .upToNextMinor(from: "0.1.0"), traits: [.defaults, "CommandLineArgumentsSupport"])
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
### Motivation

The example points to a local version of the repo, but it's now ready to point to github.

### Modifications

Changed the `Package.swift` in the getting started example to point to this repo. 

### Result

Example code will no longer look for a local copy. 

### Test Plan

I built and ran the package and it said hello!
