### PR TITLE
Update docs for the 0.2.0 release

### DIFF
--- a/Examples/hello-world-cli-example/Package.swift
+++ b/Examples/hello-world-cli-example/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-configuration",
-            .upToNextMinor(from: "0.1.0"),
+            .upToNextMinor(from: "0.2.0"),
             traits: [.defaults, "CommandLineArgumentsSupport"]
         )
     ],

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If both sources are unavailable, the fallback default of `60` is returned.
 Add the dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/apple/swift-configuration", .upToNextMinor(from: "0.1.0"))
+.package(url: "https://github.com/apple/swift-configuration", .upToNextMinor(from: "0.2.0"))
 ```
 
 Add the library dependency to your target:
@@ -94,7 +94,7 @@ To enable an additional trait on the package, update the package dependency:
 ```diff
 .package(
     url: "https://github.com/apple/swift-configuration",
-    .upToNextMinor(from: "0.1.0"),
+    .upToNextMinor(from: "0.2.0"),
 +   traits: [.defaults, "OtherFeatureSupport"]
 )
 ```

--- a/Sources/Configuration/Documentation.docc/Documentation.md
+++ b/Sources/Configuration/Documentation.docc/Documentation.md
@@ -154,7 +154,7 @@ These providers can be combined to form a hierarchy, for details check out <doc:
 Add the dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/apple/swift-configuration", .upToNextMinor(from: "0.1.0"))
+.package(url: "https://github.com/apple/swift-configuration", .upToNextMinor(from: "0.2.0"))
 ```
 
 Add the library dependency to your target:


### PR DESCRIPTION
### Motivation

We made a few breaking changes, so let's get 0.2.0 out.

### Modifications

Updated docs to refer to a 0.2.0 release instead of 0.1.0.

### Result

Accurate docs.

### Test Plan

N/A
