### PR TITLE
Add missing availability annotations in public APIs

### DIFF
--- a/Sources/Configuration/ConfigContext.swift
+++ b/Sources/Configuration/ConfigContext.swift
@@ -15,6 +15,7 @@
 /// A value that can be stored in a configuration context.
 ///
 /// Context values support common data types used for configuration metadata.
+@available(Configuration 1.0, *)
 public enum ConfigContextValue: Sendable, Equatable, Hashable {
 
     /// A string value.
@@ -30,6 +31,7 @@ public enum ConfigContextValue: Sendable, Equatable, Hashable {
     case bool(Bool)
 }
 
+@available(Configuration 1.0, *)
 extension ConfigContextValue: CustomStringConvertible {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var description: String {
@@ -46,6 +48,7 @@ extension ConfigContextValue: CustomStringConvertible {
     }
 }
 
+@available(Configuration 1.0, *)
 extension ConfigContextValue: ExpressibleByStringLiteral {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public init(stringLiteral value: String) {
@@ -53,6 +56,7 @@ extension ConfigContextValue: ExpressibleByStringLiteral {
     }
 }
 
+@available(Configuration 1.0, *)
 extension ConfigContextValue: ExpressibleByIntegerLiteral {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public init(integerLiteral value: Int) {
@@ -60,6 +64,7 @@ extension ConfigContextValue: ExpressibleByIntegerLiteral {
     }
 }
 
+@available(Configuration 1.0, *)
 extension ConfigContextValue: ExpressibleByFloatLiteral {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public init(floatLiteral value: Double) {
@@ -67,6 +72,7 @@ extension ConfigContextValue: ExpressibleByFloatLiteral {
     }
 }
 
+@available(Configuration 1.0, *)
 extension ConfigContextValue: ExpressibleByBooleanLiteral {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public init(booleanLiteral value: Bool) {
@@ -74,6 +80,7 @@ extension ConfigContextValue: ExpressibleByBooleanLiteral {
     }
 }
 
+@available(Configuration 1.0, *)
 extension [String: ConfigContextValue] {
     /// Creates a sorted string representation of the context, used primarily for sorting and logging.
     ///

--- a/Sources/Configuration/SecretsSpecifier.swift
+++ b/Sources/Configuration/SecretsSpecifier.swift
@@ -71,6 +71,7 @@
 ///     secretsSpecifier: .none
 /// )
 /// ```
+@available(Configuration 1.0, *)
 public enum SecretsSpecifier<KeyType: Sendable & Hashable, ValueType: Sendable>: Sendable {
 
     /// The library treats all configuration values as secrets.
@@ -103,6 +104,7 @@ public enum SecretsSpecifier<KeyType: Sendable & Hashable, ValueType: Sendable>:
     case dynamic(@Sendable (KeyType, ValueType) -> Bool)
 }
 
+@available(Configuration 1.0, *)
 extension SecretsSpecifier {
     /// Determines whether a configuration value should be treated as secret.
     ///

--- a/Sources/Configuration/ValueCoders/ConfigBytesFromStringDecoder.swift
+++ b/Sources/Configuration/ValueCoders/ConfigBytesFromStringDecoder.swift
@@ -34,6 +34,7 @@ import Foundation
 /// let decoder: ConfigBytesFromStringDecoder = .base64
 /// let bytes = decoder.decode("SGVsbG8gV29ybGQ=") // "Hello World" in base64
 /// ```
+@available(Configuration 1.0, *)
 public protocol ConfigBytesFromStringDecoder: Sendable {
 
     /// Decodes a string value into an array of bytes.
@@ -52,12 +53,14 @@ public protocol ConfigBytesFromStringDecoder: Sendable {
 ///
 /// This decoder interprets string configuration values as base64-encoded data
 /// and converts them to their binary representation.
+@available(Configuration 1.0, *)
 public struct ConfigBytesFromBase64StringDecoder: Sendable {
 
     /// Creates a new base64 decoder.
     public init() {}
 }
 
+@available(Configuration 1.0, *)
 extension ConfigBytesFromBase64StringDecoder: ConfigBytesFromStringDecoder {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func decode(_ value: String) -> [UInt8]? {
@@ -68,6 +71,7 @@ extension ConfigBytesFromBase64StringDecoder: ConfigBytesFromStringDecoder {
     }
 }
 
+@available(Configuration 1.0, *)
 extension ConfigBytesFromStringDecoder where Self == ConfigBytesFromBase64StringDecoder {
 
     /// A decoder that interprets string values as base64-encoded data.
@@ -85,12 +89,14 @@ extension ConfigBytesFromStringDecoder where Self == ConfigBytesFromBase64String
 /// The decoder expects strings with an even number of characters, where each
 /// pair of characters represents one byte. For example, "48656C6C6F" represents
 /// the bytes for "Hello".
+@available(Configuration 1.0, *)
 public struct ConfigBytesFromHexStringDecoder: Sendable {
 
     /// Creates a new hexadecimal decoder.
     public init() {}
 }
 
+@available(Configuration 1.0, *)
 extension ConfigBytesFromHexStringDecoder: ConfigBytesFromStringDecoder {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func decode(_ value: String) -> [UInt8]? {
@@ -113,6 +119,7 @@ extension ConfigBytesFromHexStringDecoder: ConfigBytesFromStringDecoder {
     }
 }
 
+@available(Configuration 1.0, *)
 extension ConfigBytesFromStringDecoder where Self == ConfigBytesFromHexStringDecoder {
 
     /// A decoder that interprets string values as hexadecimal-encoded data.

--- a/Tests/ConfigurationTests/ReloadingFileProviderTests.swift
+++ b/Tests/ConfigurationTests/ReloadingFileProviderTests.swift
@@ -162,7 +162,7 @@ struct ReloadingFileProviderTests {
 
             // Check empty value
             let result2 = try provider.value(forKey: ["key1"], type: .string)
-            #expect(try result2.value == nil)
+            #expect(result2.value == nil)
 
             // Update to a new valid file
             fileSystem.update(


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-configuration/issues/74.

This needed to be done before 1.0, as adding these later is an API break.

### Modifications

Added a few missing availability annotations to public APIs.

### Result

100% of the public API now has consistent availability.

### Test Plan

Tests passed.
