### PR TITLE
Fix up example project to point to the alpha

### DIFF
--- a/Examples/hello-world-cli-example/Package.swift
+++ b/Examples/hello-world-cli-example/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-configuration",
-            .upToNextMinor(from: "0.2.0"),
+            exact: "1.0.0-alpha.1",
             traits: [.defaults, "CommandLineArgumentsSupport"]
         )
     ],


### PR DESCRIPTION
### Motivation

Pre-1.0, we need to update the example projects _after_ we release the latest version because of how package editing works.

### Modifications

Updated example to use alpha.1

### Result

Up-to-date example project

### Test Plan

Verified locally.
