### PR TITLE
[Docs] Fixup context docs

### DIFF
--- a/Sources/Configuration/Documentation.docc/Guides/Choosing-access-patterns.md
+++ b/Sources/Configuration/Documentation.docc/Guides/Choosing-access-patterns.md
@@ -60,12 +60,14 @@ let timeout = try await config.fetchInt(forKey: "http.timeout", default: 30)
 
 // Fetch with context for environment-specific configuration
 let dbConnectionString = try await config.fetchRequiredString(
-    forKey: "database.url",
-    context: [
-        "environment": "production",
-        "region": "us-west-2",
-        "service": "user-service"
-    ],
+    forKey: ConfigKey(
+        "database.url",
+        context: [
+            "environment": "production",
+            "region": "us-west-2",
+            "service": "user-service"
+        ]
+    ),
     isSecret: true
 )
 ```
@@ -145,15 +147,19 @@ let context: [String: ConfigContextValue] = [
 
 // Get environment-specific database configuration
 let dbConfig = try await config.fetchRequiredString(
-    forKey: "database.connection_string",
-    context: context,
+    forKey: ConfigKey(
+        "database.connection_string",
+        context: context,
+    )
     isSecret: true
 )
 
 // Watch for region-specific timeout adjustments
 try await config.watchInt(
-    forKey: "api.timeout",
-    context: ["region": "us-west-2"],
+    forKey: ConfigKey(
+        "api.timeout",
+        context: ["region": "us-west-2"]
+    ),
     default: 5000
 ) { updates in
     for await timeout in updates {

--- a/Sources/Configuration/Documentation.docc/Guides/Choosing-reader-methods.md
+++ b/Sources/Configuration/Documentation.docc/Guides/Choosing-reader-methods.md
@@ -208,21 +208,27 @@ All variants support the same additional features:
 ```swift
 // Optional with context
 let timeout = config.int(
-    forKey: "service.timeout",
-    context: ["environment": "production", "region": "us-east-1"]
+    forKey: ConfigKey(
+        "service.timeout",
+        context: ["environment": "production", "region": "us-east-1"]
+    )
 )
 
 // Default with context
 let timeout = config.int(
-    forKey: "service.timeout",
-    context: ["environment": "production"],
+    forKey: ConfigKey(
+        "service.timeout",
+        context: ["environment": "production"]
+    ),
     default: 30
 )
 
 // Required with context
 let timeout = try config.requiredInt(
-    forKey: "service.timeout",
-    context: ["environment": "production"]
+    forKey: ConfigKey(
+        "service.timeout",
+        context: ["environment": "production"]
+    )
 )
 ```
 

--- a/Sources/Configuration/Documentation.docc/Guides/Using-in-memory-providers.md
+++ b/Sources/Configuration/Documentation.docc/Guides/Using-in-memory-providers.md
@@ -69,12 +69,16 @@ With a provider configured this way, a config reader will return the following r
 let config = ConfigReader(provider: provider)
 config.double(forKey: "http.client.timeout") // nil
 config.double(
-    forKey: "http.client.timeout", 
-    context: ["upstream": "example1.org"]
+    forKey: ConfigKey(
+        "http.client.timeout", 
+        context: ["upstream": "example1.org"]
+    )
 ) // 15.0
 config.double(
-    forKey: "http.client.timeout",
-    context: ["upstream": "example2.org"]
+    forKey: ConfigKey(
+        "http.client.timeout",
+        context: ["upstream": "example2.org"]
+    )
 ) // 30.0
 ```
 


### PR DESCRIPTION
### Motivation

As part of https://github.com/apple/swift-configuration/pull/71, we removed the string-based overrides, which had `context` as a parameter. Now the way to pass context is to explicitly construct a `ConfigKey`.

The original PR missed updating these docs.

### Modifications

Updated stale docs to be accurate.

### Result

Accurate docs.

### Test Plan

N/A
