### PR TITLE
Add YouTube video link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Swift library for reading configuration in applications and libraries.
 
 - 📚 **Documentation** is available on the [Swift Package Index](https://swiftpackageindex.com/apple/swift-configuration/documentation/configuration).
 - 💻 **Examples** are available [just below](#Examples), in the [Examples](Examples/) directory, and on the [Example use cases](https://swiftpackageindex.com/apple/swift-configuration/documentation/configuration/example-use-cases) page.
+- 📺 **Video** introduction is available [on YouTube](https://www.youtube.com/watch?v=I3lYW6OEyIs).
 - 🚀 **Contributions** are welcome, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 - 🪪 **License** is Apache 2.0, repeated in [LICENSE](LICENSE.txt).
 - 🔒 **Security** issues should be reported via the process in [SECURITY.md](SECURITY.md).

--- a/Sources/Configuration/Documentation.docc/Documentation.md
+++ b/Sources/Configuration/Documentation.docc/Documentation.md
@@ -145,6 +145,8 @@ For example, to read the timeout configuration value for an HTTP client, check o
 
 For a selection of more detailed examples, read through <doc:Example-use-cases>.
 
+For a video introduction, check out our [talk on YouTube](https://www.youtube.com/watch?v=I3lYW6OEyIs).
+
 These providers can be combined to form a hierarchy, for details check out <doc:Provider-hierarchy>.
 
 ### Quick start


### PR DESCRIPTION
### Motivation

Link to the ServerSide.swift talk about Swift Configuration from the docs, it's a good primer for folks getting started.

### Modifications

Added the link to the readme and docc landing page.

### Result

New adopters might have an easier time learning about the library, without having to read docs right away.

### Test Plan

Previewed locally.
