### PR TITLE
Docs: Update KeyMappingProvider example to use prefixKeys(with:)

### DIFF
--- a/Sources/Configuration/Providers/Wrappers/KeyMappingProvider.swift
+++ b/Sources/Configuration/Providers/Wrappers/KeyMappingProvider.swift
@@ -57,9 +57,7 @@
 ///
 /// ```swift
 /// let envProvider = EnvironmentVariablesProvider()
-/// let keyMappedEnvProvider = envProvider.mapKeys { key in
-///     key.prepending(["myapp", "prod"])
-/// }
+/// let keyMappedEnvProvider = envProvider.prefixKeys(with: ["myapp", "prod"])
 /// ```
 @available(Configuration 1.0, *)
 public struct KeyMappingProvider<Upstream: ConfigProvider>: Sendable {


### PR DESCRIPTION
### Motivation

The documentation example was using a manual `mapKeys` closure instead of the more concise `prefixKeys(with:)` convenience method provided by the library.

### Modifications

Updated the code snippet in KeyMappingProvider.swift to use the `prefixKeys(with:)` method.

### Result

The documentation example now correctly reflects the recommended and most concise way to prefix keys.

### Test Plan

Documentation-only change. Verified the syntax in the code comment.