### PR TITLE
[CI] Fix static SDK build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,8 @@ jobs:
     # Workaround https://github.com/nektos/act/issues/1875
     uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
     with:
-      env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
+      # Yams doesn't compile for Musl.
+      # env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
       command_arguments: '--swift-sdk x86_64-swift-linux-musl --target Configuration'
 
   macos-tests:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,7 +44,8 @@ jobs:
     # Workaround https://github.com/nektos/act/issues/1875
     uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
     with:
-      env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
+      # Yams doesn't compile for Musl.
+      # env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
       command_arguments: '--swift-sdk x86_64-swift-linux-musl --target Configuration'
 
   macos-tests:


### PR DESCRIPTION
### Motivation

Previously, due to overriding the commands to `--product Configuration` we weren't actually building with the Musl SDK.

### Modifications

Correctly repeat the Musl SDK triple as well as the extra argument, `--swift-sdk x86_64-swift-linux-musl --product Configuration`.

### Result

CI will correctly run for Musl now.

Credit to @finagolfin for [finding](https://github.com/apple/swift-configuration/pull/140#discussion_r2680102890) this.

### Test Plan

PR CI.
