### PR TITLE
Add UserDefaults configuration provider

### DIFF
--- a/Sources/Configuration/Providers/UserDefaults/UserDefaultsProvider.swift
+++ b/Sources/Configuration/Providers/UserDefaults/UserDefaultsProvider.swift
@@ -1,0 +1,300 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+package import Foundation
+
+/// A configuration provider that reads values from `UserDefaults`.
+///
+/// This provider bridges Apple's `UserDefaults` system with the Configuration library,
+/// allowing applications to use `UserDefaults` as a configuration source alongside
+/// other providers. Values stored in `UserDefaults` are read at query time, so changes
+/// made to `UserDefaults` by other parts of the application are reflected immediately.
+///
+/// ## Use cases
+///
+/// The `UserDefaults` provider is particularly useful for:
+/// - **Application preferences**: Reading user-configurable settings
+/// - **Platform integration**: Bridging with Settings bundles on iOS or Preferences on macOS
+/// - **Shared configuration**: Reading values from app groups using suite names
+///
+/// ## Key encoding
+///
+/// Configuration key components are joined with dots to form UserDefaults keys.
+/// For example, the configuration key `["database", "host"]` maps to the
+/// UserDefaults key `"database.host"`.
+///
+/// ## Type handling
+///
+/// The provider reads values from UserDefaults and converts them to the requested
+/// ``ConfigType``. UserDefaults natively supports strings, integers, doubles, and
+/// booleans. If a stored value cannot be converted to the requested type, a
+/// ``ConfigError/configValueNotConvertible(name:type:)`` error is thrown.
+///
+/// ## Usage
+///
+/// ```swift
+/// // Read from standard UserDefaults
+/// let provider = UserDefaultsProvider()
+///
+/// // Read from a specific suite (e.g., app group)
+/// let sharedProvider = UserDefaultsProvider(
+///     suiteName: "group.com.example.app"
+/// )
+///
+/// let config = ConfigReader(provider: provider)
+/// let timeout = config.double(forKey: "http.timeout", default: 30.0)
+/// ```
+@available(Configuration 1.0, *)
+public struct UserDefaultsProvider: Sendable {
+
+    /// The underlying snapshot of the internal state of the provider.
+    struct Snapshot: @unchecked Sendable {
+        /// The name of this instance of the provider.
+        let name: String?
+
+        /// The provider name.
+        let providerName: String
+
+        /// The UserDefaults instance to read from.
+        let defaults: UserDefaults
+
+        /// The secrets specifier.
+        let secretsSpecifier: SecretsSpecifier<String, String>
+
+        /// Create a new snapshot.
+        /// - Parameters:
+        ///   - name: The name of this instance of the provider.
+        ///   - defaults: The UserDefaults instance to read from.
+        ///   - secretsSpecifier: The secrets specifier.
+        init(
+            name: String?,
+            defaults: UserDefaults,
+            secretsSpecifier: SecretsSpecifier<String, String>
+        ) {
+            self.name = name
+            self.defaults = defaults
+            self.secretsSpecifier = secretsSpecifier
+            self.providerName = "UserDefaultsProvider[\(name ?? "")]"
+        }
+
+        /// Encode an absolute config key into a UserDefaults key string.
+        func encodeKey(_ key: AbsoluteConfigKey) -> String {
+            key.components.joined(separator: ".")
+        }
+
+        /// Convert a UserDefaults value to a ConfigValue for the requested type.
+        func convert(
+            _ rawValue: Any,
+            encodedKey: String,
+            type: ConfigType
+        ) throws -> ConfigValue {
+            let isSecret = secretsSpecifier.isSecret(key: encodedKey, value: "\(rawValue)")
+            let content: ConfigContent
+            switch type {
+            case .string:
+                guard let stringValue = rawValue as? String else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+                content = .string(stringValue)
+            case .int:
+                guard let intValue = rawValue as? Int else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+                content = .int(intValue)
+            case .double:
+                guard let doubleValue = rawValue as? Double else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+                content = .double(doubleValue)
+            case .bool:
+                guard let boolValue = rawValue as? Bool else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+                content = .bool(boolValue)
+            case .bytes:
+                if let data = rawValue as? Data {
+                    content = .bytes(Array(data))
+                } else if let bytes = rawValue as? [UInt8] {
+                    content = .bytes(bytes)
+                } else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+            case .stringArray:
+                guard let array = rawValue as? [String] else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+                content = .stringArray(array)
+            case .intArray:
+                guard let array = rawValue as? [Int] else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+                content = .intArray(array)
+            case .doubleArray:
+                guard let array = rawValue as? [Double] else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+                content = .doubleArray(array)
+            case .boolArray:
+                guard let array = rawValue as? [Bool] else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+                content = .boolArray(array)
+            case .byteChunkArray:
+                if let dataArray = rawValue as? [Data] {
+                    content = .byteChunkArray(dataArray.map { Array($0) })
+                } else if let bytesArray = rawValue as? [[UInt8]] {
+                    content = .byteChunkArray(bytesArray)
+                } else {
+                    throw ConfigError.configValueNotConvertible(name: encodedKey, type: type)
+                }
+            }
+            return ConfigValue(content, isSecret: isSecret)
+        }
+    }
+
+    /// The underlying snapshot of the internal state.
+    private let _snapshot: Snapshot
+
+    /// Creates a new UserDefaults provider that reads from the standard UserDefaults.
+    ///
+    /// - Parameters:
+    ///   - name: An optional name for the provider, used in debugging and logging.
+    ///   - secretsSpecifier: Specifies which keys or values should be marked as secrets.
+    public init(
+        name: String? = nil,
+        secretsSpecifier: SecretsSpecifier<String, String> = .none
+    ) {
+        self._snapshot = .init(
+            name: name,
+            defaults: .standard,
+            secretsSpecifier: secretsSpecifier
+        )
+    }
+
+    /// Creates a new UserDefaults provider that reads from a specific suite.
+    ///
+    /// Use this initializer to read from shared UserDefaults suites, such as
+    /// app group containers.
+    ///
+    /// - Parameters:
+    ///   - name: An optional name for the provider, used in debugging and logging.
+    ///   - suiteName: The domain identifier of the search list.
+    ///   - secretsSpecifier: Specifies which keys or values should be marked as secrets.
+    public init(
+        name: String? = nil,
+        suiteName: String,
+        secretsSpecifier: SecretsSpecifier<String, String> = .none
+    ) {
+        self._snapshot = .init(
+            name: name,
+            defaults: UserDefaults(suiteName: suiteName) ?? .standard,
+            secretsSpecifier: secretsSpecifier
+        )
+    }
+
+    /// Creates a new UserDefaults provider that reads from a specific UserDefaults instance.
+    ///
+    /// This initializer is available within the package for testing purposes.
+    /// External users should use the ``init(name:secretsSpecifier:)`` or
+    /// ``init(name:suiteName:secretsSpecifier:)`` initializers.
+    ///
+    /// - Parameters:
+    ///   - name: An optional name for the provider, used in debugging and logging.
+    ///   - defaults: The UserDefaults instance to read from.
+    ///   - secretsSpecifier: Specifies which keys or values should be marked as secrets.
+    package init(
+        name: String? = nil,
+        defaults: UserDefaults,
+        secretsSpecifier: SecretsSpecifier<String, String> = .none
+    ) {
+        self._snapshot = .init(
+            name: name,
+            defaults: defaults,
+            secretsSpecifier: secretsSpecifier
+        )
+    }
+}
+
+@available(Configuration 1.0, *)
+extension UserDefaultsProvider: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String {
+        "UserDefaultsProvider[\(_snapshot.name.map { "\($0)" } ?? "")]"
+    }
+}
+
+@available(Configuration 1.0, *)
+extension UserDefaultsProvider.Snapshot: ConfigSnapshot {
+    func value(
+        forKey key: AbsoluteConfigKey,
+        type: ConfigType
+    ) throws -> LookupResult {
+        let encodedKey = encodeKey(key)
+        return try withConfigValueLookup(encodedKey: encodedKey) {
+            guard let rawValue = defaults.object(forKey: encodedKey) else {
+                return nil
+            }
+            return try convert(rawValue, encodedKey: encodedKey, type: type)
+        }
+    }
+}
+
+@available(Configuration 1.0, *)
+extension UserDefaultsProvider: ConfigProvider {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var providerName: String {
+        _snapshot.providerName
+    }
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func value(
+        forKey key: AbsoluteConfigKey,
+        type: ConfigType
+    ) throws -> LookupResult {
+        try _snapshot.value(forKey: key, type: type)
+    }
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func fetchValue(
+        forKey key: AbsoluteConfigKey,
+        type: ConfigType
+    ) async throws -> LookupResult {
+        try value(forKey: key, type: type)
+    }
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func watchValue<Return: ~Copyable>(
+        forKey key: AbsoluteConfigKey,
+        type: ConfigType,
+        updatesHandler: (
+            _ updates: ConfigUpdatesAsyncSequence<Result<LookupResult, any Error>, Never>
+        ) async throws -> Return
+    ) async throws -> Return {
+        try await watchValueFromValue(forKey: key, type: type, updatesHandler: updatesHandler)
+    }
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func snapshot() -> any ConfigSnapshot {
+        _snapshot
+    }
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public func watchSnapshot<Return: ~Copyable>(
+        updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<any ConfigSnapshot, Never>) async throws -> Return
+    ) async throws -> Return {
+        try await watchSnapshotFromSnapshot(updatesHandler: updatesHandler)
+    }
+}
+#endif

--- a/Tests/ConfigurationTests/UserDefaultsProviderTests.swift
+++ b/Tests/ConfigurationTests/UserDefaultsProviderTests.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Testing
+import ConfigurationTestingInternal
+@testable import Configuration
+import Foundation
+import ConfigurationTesting
+
+struct UserDefaultsProviderTests {
+
+    /// A unique suite name for test isolation.
+    private static let testSuiteName = "com.apple.swift-configuration.tests.\(UUID().uuidString)"
+
+    /// Creates a UserDefaults instance populated with the standard test data.
+    private static func makeTestDefaults() -> UserDefaults {
+        let defaults = UserDefaults(suiteName: testSuiteName)!
+        defaults.set("Hello", forKey: "string")
+        defaults.set("Other Hello", forKey: "other.string")
+        defaults.set(42, forKey: "int")
+        defaults.set(24, forKey: "other.int")
+        defaults.set(3.14, forKey: "double")
+        defaults.set(2.72, forKey: "other.double")
+        defaults.set(true, forKey: "bool")
+        defaults.set(false, forKey: "other.bool")
+        defaults.set(Data([UInt8].magic), forKey: "bytes")
+        defaults.set(Data([UInt8].magic2), forKey: "other.bytes")
+        defaults.set(["Hello", "World"], forKey: "stringy.array")
+        defaults.set(["Hello", "Swift"], forKey: "other.stringy.array")
+        defaults.set([42, 24], forKey: "inty.array")
+        defaults.set([16, 32], forKey: "other.inty.array")
+        defaults.set([3.14, 2.72], forKey: "doubly.array")
+        defaults.set([0.9, 1.8], forKey: "other.doubly.array")
+        defaults.set([true, false], forKey: "booly.array")
+        defaults.set([false, true, true], forKey: "other.booly.array")
+        defaults.set([Data([UInt8].magic), Data([UInt8].magic2)], forKey: "byteChunky.array")
+        defaults.set(
+            [Data([UInt8].magic), Data([UInt8].magic2), Data([UInt8].magic)],
+            forKey: "other.byteChunky.array"
+        )
+        return defaults
+    }
+
+    @available(Configuration 1.0, *)
+    var provider: UserDefaultsProvider {
+        let defaults = Self.makeTestDefaults()
+        return UserDefaultsProvider(name: "test", defaults: defaults)
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func printingDescription() throws {
+        let expectedDescription = "UserDefaultsProvider[test]"
+        #expect(provider.description == expectedDescription)
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func stringValue() throws {
+        let result = try provider.value(forKey: "string", type: .string)
+        #expect(result.value?.content == .string("Hello"))
+        #expect(result.encodedKey == "string")
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func intValue() throws {
+        let result = try provider.value(forKey: "int", type: .int)
+        #expect(result.value?.content == .int(42))
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func doubleValue() throws {
+        let result = try provider.value(forKey: "double", type: .double)
+        #expect(result.value?.content == .double(3.14))
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func boolValue() throws {
+        let result = try provider.value(forKey: "bool", type: .bool)
+        #expect(result.value?.content == .bool(true))
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func bytesValue() throws {
+        let result = try provider.value(forKey: "bytes", type: .bytes)
+        #expect(result.value?.content == .bytes(.magic))
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func stringArrayValue() throws {
+        let result = try provider.value(forKey: "stringy.array", type: .stringArray)
+        #expect(result.value?.content == .stringArray(["Hello", "World"]))
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func missingValue() throws {
+        let result = try provider.value(forKey: "nonexistent", type: .string)
+        #expect(result.value == nil)
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func typeMismatch() throws {
+        #expect(throws: ConfigError.self) {
+            _ = try provider.value(forKey: "string", type: .int)
+        }
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func nestedKey() throws {
+        let result = try provider.value(forKey: "other.string", type: .string)
+        #expect(result.value?.content == .string("Other Hello"))
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func snapshot() throws {
+        let snap = provider.snapshot()
+        let result = try snap.value(forKey: "string", type: .string)
+        #expect(result.value?.content == .string("Hello"))
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func fetchValue() async throws {
+        let result = try await provider.fetchValue(forKey: "int", type: .int)
+        #expect(result.value?.content == .int(42))
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func compat() async throws {
+        try await ProviderCompatTest(provider: provider).runTest()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Adds `UserDefaultsProvider` that reads configuration values from Apple's `UserDefaults` system, bridging platform preferences with the Configuration library.

- Reads from standard `UserDefaults` or a specific suite name (for app groups)
- Supports all `ConfigType` values (string, int, double, bool, bytes, and array variants)
- Reads values at query time, reflecting live `UserDefaults` changes
- Joins key components with dots for UserDefaults key encoding (e.g., `["http", "timeout"]` → `"http.timeout"`)
- Supports `SecretsSpecifier` for marking sensitive keys
- Darwin-only (`#if canImport(Darwin)`)

Closes #107

Regarding the question in the issue about UserDefaults vs CFPreferences: this implementation wraps `UserDefaults`, which itself wraps `CFPreferences` under the hood. This provides the standard Swift API while covering CFPreferences functionality. A separate `CFPreferencesProvider` could be added later if direct Core Foundation access is needed.

## Example

```swift
// Read from standard UserDefaults
let provider = UserDefaultsProvider()

// Read from an app group suite
let shared = UserDefaultsProvider(suiteName: "group.com.example.app")

let config = ConfigReader(provider: provider)
let timeout = config.double(forKey: "http.timeout", default: 30.0)
```

## Test plan

- [x] String, Int, Double, Bool, Bytes value retrieval
- [x] Array value retrieval (stringArray, intArray, etc.)
- [x] Missing key returns nil
- [x] Type mismatch throws `ConfigError`
- [x] Nested/dotted key encoding
- [x] Snapshot access
- [x] Async fetch
- [x] `ProviderCompatTest` compatibility suite
- [ ] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)