### PR TITLE
Add example app using xcode project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,6 +150,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ">=26.4"
       - name: Build
         run: ./Scripts/test-xcode-examples.sh
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,26 @@ jobs:
       name: "Example packages"
       matrix_string: '${{ needs.construct-example-packages-matrix.outputs.example-packages-matrix }}'
 
+  example-xcode-projects:
+    strategy:
+      matrix:
+        destination: 
+          - generic/platform=macOS
+          - generic/platform=iOS Simulator
+          - generic/platform=tvOS Simulator
+          - generic/platform=visionOS Simulator
+    name: Example Xcode projects
+    runs-on: macos-26
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Build
+        run: ./Scripts/test-xcode-examples.sh
+        env:
+          XCODEBUILD_DESTINATION: ${{ matrix.destination }}
+
   benchmarks:
     name: Benchmarks
     uses: apple/swift-nio/.github/workflows/benchmarks.yml@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,30 @@ jobs:
       name: "Example packages"
       matrix_string: '${{ needs.construct-example-packages-matrix.outputs.example-packages-matrix }}'
 
+  example-xcode-projects:
+    strategy:
+      matrix:
+        destination: 
+          - generic/platform=macOS
+          - generic/platform=iOS Simulator
+          - generic/platform=tvOS Simulator
+          - generic/platform=visionOS Simulator
+    name: Example Xcode projects
+    runs-on: macos-26
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ">=26.4"
+      - name: Build
+        run: ./Scripts/test-xcode-examples.sh
+        env:
+          XCODEBUILD_DESTINATION: ${{ matrix.destination }}
+
   benchmarks:
     name: Benchmarks
     uses: apple/swift-nio/.github/workflows/benchmarks.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -157,6 +157,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ">=26.4"
       - name: Build
         run: ./Scripts/test-xcode-examples.sh
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -142,6 +142,26 @@ jobs:
       name: "Example packages"
       matrix_string: '${{ needs.construct-example-packages-matrix.outputs.example-packages-matrix }}'
 
+  example-xcode-projects:
+    strategy:
+      matrix:
+        destination: 
+          - generic/platform=macOS
+          - generic/platform=iOS Simulator
+          - generic/platform=tvOS Simulator
+          - generic/platform=visionOS Simulator
+    name: Example Xcode projects
+    runs-on: macos-26
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Build
+        run: ./Scripts/test-xcode-examples.sh
+        env:
+          XCODEBUILD_DESTINATION: ${{ matrix.destination }}
+
   benchmarks:
     name: Benchmarks
     uses: apple/swift-nio/.github/workflows/benchmarks.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -142,6 +142,30 @@ jobs:
       name: "Example packages"
       matrix_string: '${{ needs.construct-example-packages-matrix.outputs.example-packages-matrix }}'
 
+  example-xcode-projects:
+    strategy:
+      matrix:
+        destination: 
+          - generic/platform=macOS
+          - generic/platform=iOS Simulator
+          - generic/platform=tvOS Simulator
+          - generic/platform=visionOS Simulator
+    name: Example Xcode projects
+    runs-on: macos-26
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ">=26.4"
+      - name: Build
+        run: ./Scripts/test-xcode-examples.sh
+        env:
+          XCODEBUILD_DESTINATION: ${{ matrix.destination }}
+
   benchmarks:
     name: Benchmarks
     uses: apple/swift-nio/.github/workflows/benchmarks.yml@main

--- a/Examples/HelloWorldAppExample/.gitignore
+++ b/Examples/HelloWorldAppExample/.gitignore
@@ -1,0 +1,6 @@
+xcuserdata/
+*.ipa
+*.dSYM.zip
+*.dSYM
+build/
+.build/

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.pbxproj
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.pbxproj
@@ -1,0 +1,377 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 100;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7E0A346A2F6A190700D884F7 /* Configuration in Frameworks */ = {isa = PBXBuildFile; productRef = 7E0A34692F6A190700D884F7 /* Configuration */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		7EB913542F69F47600A9BD65 /* HelloWorldAppExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorldAppExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		7EB913562F69F47600A9BD65 /* HelloWorldAppExample */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = HelloWorldAppExample;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7EB913512F69F47600A9BD65 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+				7E0A346A2F6A190700D884F7 /* Configuration in Frameworks */,
+			);
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7EB9134B2F69F47600A9BD65 = {
+			isa = PBXGroup;
+			children = (
+				7EB913562F69F47600A9BD65 /* HelloWorldAppExample */,
+				7EB913552F69F47600A9BD65 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7EB913552F69F47600A9BD65 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7EB913542F69F47600A9BD65 /* HelloWorldAppExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7EB913532F69F47600A9BD65 /* HelloWorldAppExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7EB9135F2F69F47800A9BD65 /* Build configuration list for PBXNativeTarget "HelloWorldAppExample" */;
+			buildPhases = (
+				7EB913502F69F47600A9BD65 /* Sources */,
+				7EB913512F69F47600A9BD65 /* Frameworks */,
+				7EB913522F69F47600A9BD65 /* Resources */,
+			);
+			buildRules = (
+			);
+			fileSystemSynchronizedGroups = (
+				7EB913562F69F47600A9BD65 /* HelloWorldAppExample */,
+			);
+			name = HelloWorldAppExample;
+			packageProductDependencies = (
+				7E0A34692F6A190700D884F7 /* Configuration */,
+			);
+			productName = HelloWorldAppExample;
+			productReference = 7EB913542F69F47600A9BD65 /* HelloWorldAppExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7EB9134C2F69F47600A9BD65 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2640;
+				TargetAttributes = {
+					7EB913532F69F47600A9BD65 = {
+						CreatedOnToolsVersion = 26.3;
+					};
+				};
+			};
+			buildConfigurationList = 7EB9134F2F69F47600A9BD65 /* Build configuration list for PBXProject "HelloWorldAppExample" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7EB9134B2F69F47600A9BD65;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				7E0A34682F6A190700D884F7 /* XCLocalSwiftPackageReference "../../../swift-configuration" */,
+			);
+			preferredProjectObjectVersion = 100;
+			productRefGroup = 7EB913552F69F47600A9BD65 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7EB913532F69F47600A9BD65 /* HelloWorldAppExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7EB913522F69F47600A9BD65 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			files = (
+			);
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7EB913502F69F47600A9BD65 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+			);
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		7EB9135D2F69F47800A9BD65 /* Debug configuration for PBXProject "HelloWorldAppExample" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TVOS_DEPLOYMENT_TARGET = 26.0;
+				XROS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Debug;
+		};
+		7EB9135E2F69F47800A9BD65 /* Release configuration for PBXProject "HelloWorldAppExample" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TVOS_DEPLOYMENT_TARGET = 26.0;
+				XROS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Release;
+		};
+		7EB913602F69F47800A9BD65 /* Debug configuration for PBXNativeTarget "HelloWorldAppExample" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.HelloWorldAppExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+			};
+			name = Debug;
+		};
+		7EB913612F69F47800A9BD65 /* Release configuration for PBXNativeTarget "HelloWorldAppExample" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.HelloWorldAppExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7EB9134F2F69F47600A9BD65 /* Build configuration list for PBXProject "HelloWorldAppExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7EB9135D2F69F47800A9BD65 /* Debug configuration for PBXProject "HelloWorldAppExample" */,
+				7EB9135E2F69F47800A9BD65 /* Release configuration for PBXProject "HelloWorldAppExample" */,
+			);
+			defaultConfigurationName = Release;
+		};
+		7EB9135F2F69F47800A9BD65 /* Build configuration list for PBXNativeTarget "HelloWorldAppExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7EB913602F69F47800A9BD65 /* Debug configuration for PBXNativeTarget "HelloWorldAppExample" */,
+				7EB913612F69F47800A9BD65 /* Release configuration for PBXNativeTarget "HelloWorldAppExample" */,
+			);
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		7E0A34682F6A190700D884F7 /* XCLocalSwiftPackageReference "../../../swift-configuration" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../../../swift-configuration";
+			traits = (
+				CommandLineArguments,
+				default,
+			);
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		7E0A34692F6A190700D884F7 /* Configuration */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Configuration;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 7EB9134C2F69F47600A9BD65 /* Project object */;
+}

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.pbxproj
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 100;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -25,11 +25,9 @@
 /* Begin PBXFrameworksBuildPhase section */
 		7EB913512F69F47600A9BD65 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				7E0A346A2F6A190700D884F7 /* Configuration in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -63,8 +61,6 @@
 			);
 			buildRules = (
 			);
-			dependencies = (
-			);
 			fileSystemSynchronizedGroups = (
 				7EB913562F69F47600A9BD65 /* HelloWorldAppExample */,
 			);
@@ -84,7 +80,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 2630;
-				LastUpgradeCheck = 2630;
+				LastUpgradeCheck = 2640;
 				TargetAttributes = {
 					7EB913532F69F47600A9BD65 = {
 						CreatedOnToolsVersion = 26.3;
@@ -103,7 +99,7 @@
 			packageReferences = (
 				7E0A34682F6A190700D884F7 /* XCLocalSwiftPackageReference "../../../swift-configuration" */,
 			);
-			preferredProjectObjectVersion = 77;
+			preferredProjectObjectVersion = 100;
 			productRefGroup = 7EB913552F69F47600A9BD65 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -116,25 +112,21 @@
 /* Begin PBXResourcesBuildPhase section */
 		7EB913522F69F47600A9BD65 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		7EB913502F69F47600A9BD65 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		7EB9135D2F69F47800A9BD65 /* Debug */ = {
+		7EB9135D2F69F47800A9BD65 /* Debug configuration for PBXProject "HelloWorldAppExample" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -168,6 +160,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -186,16 +179,25 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TVOS_DEPLOYMENT_TARGET = 26.0;
+				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = Debug;
 		};
-		7EB9135E2F69F47800A9BD65 /* Release */ = {
+		7EB9135E2F69F47800A9BD65 /* Release configuration for PBXProject "HelloWorldAppExample" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -229,6 +231,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -241,20 +244,30 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TVOS_DEPLOYMENT_TARGET = 26.0;
+				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = Release;
 		};
-		7EB913602F69F47800A9BD65 /* Debug */ = {
+		7EB913602F69F47800A9BD65 /* Debug configuration for PBXNativeTarget "HelloWorldAppExample" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -269,10 +282,8 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.HelloWorldAppExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -281,23 +292,19 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
-				XROS_DEPLOYMENT_TARGET = 26.2;
 			};
 			name = Debug;
 		};
-		7EB913612F69F47800A9BD65 /* Release */ = {
+		7EB913612F69F47800A9BD65 /* Release configuration for PBXNativeTarget "HelloWorldAppExample" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -312,10 +319,8 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.HelloWorldAppExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -324,13 +329,8 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
-				XROS_DEPLOYMENT_TARGET = 26.2;
 			};
 			name = Release;
 		};
@@ -340,19 +340,17 @@
 		7EB9134F2F69F47600A9BD65 /* Build configuration list for PBXProject "HelloWorldAppExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7EB9135D2F69F47800A9BD65 /* Debug */,
-				7EB9135E2F69F47800A9BD65 /* Release */,
+				7EB9135D2F69F47800A9BD65 /* Debug configuration for PBXProject "HelloWorldAppExample" */,
+				7EB9135E2F69F47800A9BD65 /* Release configuration for PBXProject "HelloWorldAppExample" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		7EB9135F2F69F47800A9BD65 /* Build configuration list for PBXNativeTarget "HelloWorldAppExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7EB913602F69F47800A9BD65 /* Debug */,
-				7EB913612F69F47800A9BD65 /* Release */,
+				7EB913602F69F47800A9BD65 /* Debug configuration for PBXNativeTarget "HelloWorldAppExample" */,
+				7EB913612F69F47800A9BD65 /* Release configuration for PBXNativeTarget "HelloWorldAppExample" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
@@ -361,6 +359,10 @@
 		7E0A34682F6A190700D884F7 /* XCLocalSwiftPackageReference "../../../swift-configuration" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "../../../swift-configuration";
+			traits = (
+				CommandLineArguments,
+				default,
+			);
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.pbxproj
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.pbxproj
@@ -1,0 +1,375 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7E0A346A2F6A190700D884F7 /* Configuration in Frameworks */ = {isa = PBXBuildFile; productRef = 7E0A34692F6A190700D884F7 /* Configuration */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		7EB913542F69F47600A9BD65 /* HelloWorldAppExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorldAppExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		7EB913562F69F47600A9BD65 /* HelloWorldAppExample */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = HelloWorldAppExample;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7EB913512F69F47600A9BD65 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E0A346A2F6A190700D884F7 /* Configuration in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7EB9134B2F69F47600A9BD65 = {
+			isa = PBXGroup;
+			children = (
+				7EB913562F69F47600A9BD65 /* HelloWorldAppExample */,
+				7EB913552F69F47600A9BD65 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7EB913552F69F47600A9BD65 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7EB913542F69F47600A9BD65 /* HelloWorldAppExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7EB913532F69F47600A9BD65 /* HelloWorldAppExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7EB9135F2F69F47800A9BD65 /* Build configuration list for PBXNativeTarget "HelloWorldAppExample" */;
+			buildPhases = (
+				7EB913502F69F47600A9BD65 /* Sources */,
+				7EB913512F69F47600A9BD65 /* Frameworks */,
+				7EB913522F69F47600A9BD65 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				7EB913562F69F47600A9BD65 /* HelloWorldAppExample */,
+			);
+			name = HelloWorldAppExample;
+			packageProductDependencies = (
+				7E0A34692F6A190700D884F7 /* Configuration */,
+			);
+			productName = HelloWorldAppExample;
+			productReference = 7EB913542F69F47600A9BD65 /* HelloWorldAppExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7EB9134C2F69F47600A9BD65 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2630;
+				TargetAttributes = {
+					7EB913532F69F47600A9BD65 = {
+						CreatedOnToolsVersion = 26.3;
+					};
+				};
+			};
+			buildConfigurationList = 7EB9134F2F69F47600A9BD65 /* Build configuration list for PBXProject "HelloWorldAppExample" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7EB9134B2F69F47600A9BD65;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				7E0A34682F6A190700D884F7 /* XCLocalSwiftPackageReference "../../../swift-configuration" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 7EB913552F69F47600A9BD65 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7EB913532F69F47600A9BD65 /* HelloWorldAppExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7EB913522F69F47600A9BD65 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7EB913502F69F47600A9BD65 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		7EB9135D2F69F47800A9BD65 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		7EB9135E2F69F47800A9BD65 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		7EB913602F69F47800A9BD65 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "apple.swift-configuration.HelloWorldAppExample";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+				XROS_DEPLOYMENT_TARGET = 26.2;
+			};
+			name = Debug;
+		};
+		7EB913612F69F47800A9BD65 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "apple.swift-configuration.HelloWorldAppExample";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+				XROS_DEPLOYMENT_TARGET = 26.2;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7EB9134F2F69F47600A9BD65 /* Build configuration list for PBXProject "HelloWorldAppExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7EB9135D2F69F47800A9BD65 /* Debug */,
+				7EB9135E2F69F47800A9BD65 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7EB9135F2F69F47800A9BD65 /* Build configuration list for PBXNativeTarget "HelloWorldAppExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7EB913602F69F47800A9BD65 /* Debug */,
+				7EB913612F69F47800A9BD65 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		7E0A34682F6A190700D884F7 /* XCLocalSwiftPackageReference "../../../swift-configuration" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../../../swift-configuration";
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		7E0A34692F6A190700D884F7 /* Configuration */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Configuration;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 7EB9134C2F69F47600A9BD65 /* Project object */;
+}

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.pbxproj
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "apple.swift-configuration.HelloWorldAppExample";
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.HelloWorldAppExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -317,7 +317,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "apple.swift-configuration.HelloWorldAppExample";
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.HelloWorldAppExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/xcshareddata/xcschemes/HelloWorldAppExample.xcscheme
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/xcshareddata/xcschemes/HelloWorldAppExample.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7EB913532F69F47600A9BD65"
+               BuildableName = "HelloWorldAppExample.app"
+               BlueprintName = "HelloWorldAppExample"
+               ReferencedContainer = "container:HelloWorldAppExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7EB913532F69F47600A9BD65"
+            BuildableName = "HelloWorldAppExample.app"
+            BlueprintName = "HelloWorldAppExample"
+            ReferencedContainer = "container:HelloWorldAppExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "GREETED_NAME"
+            value = "Environment"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7EB913532F69F47600A9BD65"
+            BuildableName = "HelloWorldAppExample.app"
+            BlueprintName = "HelloWorldAppExample"
+            ReferencedContainer = "container:HelloWorldAppExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/xcshareddata/xcschemes/HelloWorldAppExample.xcscheme
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/xcshareddata/xcschemes/HelloWorldAppExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2630"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:HelloWorldAppExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--greeted-name CommandLine"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "GREETED_NAME"

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/xcshareddata/xcschemes/HelloWorldAppExample.xcscheme
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample.xcodeproj/xcshareddata/xcschemes/HelloWorldAppExample.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7EB913532F69F47600A9BD65"
+               BuildableName = "HelloWorldAppExample.app"
+               BlueprintName = "HelloWorldAppExample"
+               ReferencedContainer = "container:HelloWorldAppExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7EB913532F69F47600A9BD65"
+            BuildableName = "HelloWorldAppExample.app"
+            BlueprintName = "HelloWorldAppExample"
+            ReferencedContainer = "container:HelloWorldAppExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--greeted-name=CommandLine"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "GREETED_NAME"
+            value = "Environment"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7EB913532F69F47600A9BD65"
+            BuildableName = "HelloWorldAppExample.app"
+            BlueprintName = "HelloWorldAppExample"
+            ReferencedContainer = "container:HelloWorldAppExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample/HelloWorldApp.swift
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample/HelloWorldApp.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Configuration
+import SwiftUI
+
+@main
+struct HelloWorldAppExampleApp: App {
+    let greetedName: String
+
+    init() {
+        let config = ConfigReader(providers: [
+            CommandLineArgumentsProvider(),
+            EnvironmentVariablesProvider(),
+        ])
+        greetedName = config.string(forKey: "greetedName", default: "World")
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            HelloWorldView(greetedName: greetedName)
+        }
+    }
+}

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample/HelloWorldApp.swift
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample/HelloWorldApp.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Configuration
+import SwiftUI
+
+@main
+struct HelloWorldAppExampleApp: App {
+    let greetedName: String
+
+    init() {
+        let config = ConfigReader(providers: [
+            EnvironmentVariablesProvider(),
+            InMemoryProvider(values: ["greetedName": "Memory"]),
+        ])
+        greetedName = config.string(forKey: "greetedName", default: "World")
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            HelloWorldView(greetedName: greetedName)
+        }
+    }
+}

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample/HelloWorldApp.swift
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample/HelloWorldApp.swift
@@ -21,8 +21,8 @@ struct HelloWorldAppExampleApp: App {
 
     init() {
         let config = ConfigReader(providers: [
+            CommandLineArgumentsProvider(),
             EnvironmentVariablesProvider(),
-            InMemoryProvider(values: ["greetedName": "Memory"]),
         ])
         greetedName = config.string(forKey: "greetedName", default: "World")
     }

--- a/Examples/HelloWorldAppExample/HelloWorldAppExample/HelloWorldView.swift
+++ b/Examples/HelloWorldAppExample/HelloWorldAppExample/HelloWorldView.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftUI
+
+struct HelloWorldView: View {
+    let greetedName: String
+
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, \(greetedName)!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    HelloWorldView(greetedName: "World")
+}

--- a/Examples/HelloWorldAppExample/README.md
+++ b/Examples/HelloWorldAppExample/README.md
@@ -1,0 +1,63 @@
+# Hello World App Example
+
+> **Disclaimer:** This example is designed to demonstrate basic concepts of Swift Configuration and is not production-ready code. It lacks comprehensive error handling, testing, and other features required for production use.
+
+## Overview
+
+This example demonstrates the fundamental concepts of Swift Configuration through a simple app that displays a personalized greeting message. The application showcases how to:
+
+- Set up multiple configuration providers in a hierarchy.
+- Use environment variables and command-line arguments as configuration sources.
+- Read configuration values with type safety and default fallbacks.
+
+## What it does
+
+The application reads a `greetedName` configuration value from multiple sources and displays `"Hello, {name}!"`. The configuration sources are prioritized as follows:
+
+1. **Command-line configuration** (highest priority)
+2. **Environment variables** (lower priority)
+3. **Default value** (`"World"` - used when no other source provides the value)
+
+## Step-by-step instructions
+
+### Step 1: Build the example
+
+Open the project in Xcode, and select a target destination.
+
+### Step 2: Run with default value
+
+Run the application without any configuration to see the default behavior:
+
+**Expected output:**
+```
+Hello, World!
+```
+
+### Step 3: Run with environment variable
+
+Edit the current scheme and enable the `GREETED_NAME` environment variable, then run the application.
+
+**Expected output:**
+```
+Hello, Environment!
+```
+
+### Step 4: Run with command-line argument
+
+Edit the current scheme and enable the `--greeted-name` argument, then run the application.
+
+**Expected output:**
+```
+Hello, CommandLine!
+```
+
+### Step 5: Demonstrate provider priority
+
+Edit the current scheme and enable both the `--greeted-name` argument and the `GREETED_NAME` environment variable, then run the application.
+
+**Expected output:**
+```
+Hello, CommandLine!
+```
+
+This demonstrates that command-line arguments take precedence over environment variables in the provider hierarchy.

--- a/Examples/HelloWorldAppExample/README.md
+++ b/Examples/HelloWorldAppExample/README.md
@@ -7,15 +7,15 @@
 This example demonstrates the fundamental concepts of Swift Configuration through a simple app that displays a personalized greeting message. The application showcases how to:
 
 - Set up multiple configuration providers in a hierarchy.
-- Use environment variables and in-memory arguments as configuration sources.
+- Use environment variables and command-line arguments as configuration sources.
 - Read configuration values with type safety and default fallbacks.
 
 ## What it does
 
 The application reads a `greetedName` configuration value from multiple sources and displays `"Hello, {name}!"`. The configuration sources are prioritized as follows:
 
-1. **Environment variabless** (highest priority)
-2. **In-memory configuration** (lower priority)
+1. **Command-line configuration** (highest priority)
+2. **Environment variables** (lower priority)
 3. **Default value** (`"World"` - used when no other source provides the value)
 
 ## Step-by-step instructions
@@ -30,16 +30,34 @@ Run the application without any configuration to see the default behavior:
 
 **Expected output:**
 ```
-Hello, Memory!
+Hello, World!
 ```
 
 ### Step 3: Run with environment variable
 
-Edit the current scheme and set the `GREETED_NAME` environment variable, then run the application:
+Edit the current scheme and enable the `GREETED_NAME` environment variable, then run the application.
 
 **Expected output:**
 ```
 Hello, Environment!
 ```
 
-This demonstrates that environment variables take precedence over in-memory configuration in the provider hierarchy.
+### Step 4: Run with command-line argument
+
+Edit the current scheme and enable the `--greeted-name` argument, then run the application.
+
+**Expected output:**
+```
+Hello, CommandLine!
+```
+
+### Step 5: Demonstrate provider priority
+
+Edit the current scheme and enable both the `--greeted-name` argument and the `GREETED_NAME` environment variable, then run the application.
+
+**Expected output:**
+```
+Hello, CommandLine!
+```
+
+This demonstrates that command-line arguments take precedence over environment variables in the provider hierarchy.

--- a/Examples/HelloWorldAppExample/README.md
+++ b/Examples/HelloWorldAppExample/README.md
@@ -1,0 +1,45 @@
+# Hello World App Example
+
+> **Disclaimer:** This example is designed to demonstrate basic concepts of Swift Configuration and is not production-ready code. It lacks comprehensive error handling, testing, and other features required for production use.
+
+## Overview
+
+This example demonstrates the fundamental concepts of Swift Configuration through a simple app that displays a personalized greeting message. The application showcases how to:
+
+- Set up multiple configuration providers in a hierarchy.
+- Use environment variables and in-memory arguments as configuration sources.
+- Read configuration values with type safety and default fallbacks.
+
+## What it does
+
+The application reads a `greetedName` configuration value from multiple sources and displays `"Hello, {name}!"`. The configuration sources are prioritized as follows:
+
+1. **Environment variabless** (highest priority)
+2. **In-memory configuration** (lower priority)
+3. **Default value** (`"World"` - used when no other source provides the value)
+
+## Step-by-step instructions
+
+### Step 1: Build the example
+
+Open the project in Xcode, and select a target destination.
+
+### Step 2: Run with default value
+
+Run the application without any configuration to see the default behavior:
+
+**Expected output:**
+```
+Hello, Memory!
+```
+
+### Step 3: Run with environment variable
+
+Edit the current scheme and set the `GREETED_NAME` environment variable, then run the application:
+
+**Expected output:**
+```
+Hello, Environment!
+```
+
+This demonstrates that environment variables take precedence over in-memory configuration in the provider hierarchy.

--- a/Scripts/test-xcode-examples.sh
+++ b/Scripts/test-xcode-examples.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+log "Checking required executables..."
+XCODEBUILD_BIN=${XCODEBUILD_BIN:-$(command -v xcodebuild || xcrun -f swift)} || fatal "XCODEBUILD_BIN unset and no xcodebuild on PATH"
+
+CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
+TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
+
+PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
+EXAMPLES_PACKAGE_PATH="${PACKAGE_PATH}/Examples"
+SHARED_EXAMPLE_HARNESS_PACKAGE_PATH="${TMP_DIR}/example-harness"
+SHARED_PACKAGE_SCRATCH_PATH="${TMP_DIR}/example-scratch"
+SHARED_PACKAGE_CACHE_PATH="${TMP_DIR}/example-cache"
+XCODEBUILD_DESTINATION=${XCODEBUILD_DESTINATION:-"generic/platform=macOS"}
+ORIGINAL_LOCAL_DEPENDENCY_PATH=${ORIGINAL_LOCAL_DEPENDENCY_PATH:-"../../../swift-configuration"}
+
+for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name '*.xcodeproj' -type d -print0 | xargs -0 dirname | sort); do
+
+    EXAMPLE_PACKAGE_NAME="$(basename "${EXAMPLE_PACKAGE_PATH}")"
+
+    if [[ "${SINGLE_EXAMPLE_PACKAGE:-${EXAMPLE_PACKAGE_NAME}}" != "${EXAMPLE_PACKAGE_NAME}" ]]; then
+        log "Skipping example: ${EXAMPLE_PACKAGE_NAME}"
+        continue
+    fi
+
+    log "Recreating shared example harness directory: ${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+    rm -rf "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+    mkdir -v "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+
+    log "Copying example contents from ${EXAMPLE_PACKAGE_NAME} to ${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+    git archive HEAD "${EXAMPLE_PACKAGE_PATH}" --format tar | tar -C "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" -xvf- --strip-components 2
+
+    # GNU tar has --touch, but BSD tar does not, so we'll use touch directly.
+    log "Updating mtime of example contents..."
+    find "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" -print0 | xargs -0 -n1 touch -m
+
+    log "Building example app: ${EXAMPLE_PACKAGE_NAME}"
+    ( 
+        cd "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+
+        # There is no CLI to modify dependencies, revert to sed
+        PBXPROJ=$(find . -name "project.pbxproj" -type f -maxdepth 2)
+        sed -i '' "s|${ORIGINAL_LOCAL_DEPENDENCY_PATH}|${PACKAGE_PATH}|g" "$PBXPROJ"
+
+        "${XCODEBUILD_BIN}" build \
+            -scheme "${EXAMPLE_PACKAGE_NAME}" \
+            -destination "${XCODEBUILD_DESTINATION}" \
+            -clonedSourcePackagesDirPath "${SHARED_PACKAGE_CACHE_PATH}" \
+            -skipPackageUpdates \
+            -derivedDataPath "${SHARED_PACKAGE_SCRATCH_PATH}"
+        log "✅ Successfully built the example app ${EXAMPLE_PACKAGE_NAME}."
+    )
+done

--- a/Scripts/test-xcode-examples.sh
+++ b/Scripts/test-xcode-examples.sh
@@ -15,8 +15,9 @@ TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
 PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
 EXAMPLES_PACKAGE_PATH="${PACKAGE_PATH}/Examples"
 SHARED_EXAMPLE_HARNESS_PACKAGE_PATH="${TMP_DIR}/example-harness"
-SHARED_PACKAGE_SCRATCH_PATH="${TMP_DIR}/example-scratch"
+SHARED_DERIVED_DATA_PATH="${TMP_DIR}/example-derived-data"
 SHARED_PACKAGE_CACHE_PATH="${TMP_DIR}/example-cache"
+SHARED_CLONED_SOURCES_PATH="${TMP_DIR}/example-cloned-sources"
 XCODEBUILD_DESTINATION=${XCODEBUILD_DESTINATION:-"generic/platform=macOS"}
 ORIGINAL_LOCAL_DEPENDENCY_PATH=${ORIGINAL_LOCAL_DEPENDENCY_PATH:-"../../../swift-configuration"}
 
@@ -29,6 +30,10 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
         continue
     fi
 
+    log "Recreating shared derived data directory: ${SHARED_DERIVED_DATA_PATH}"
+    rm -rf "${SHARED_DERIVED_DATA_PATH}"
+    mkdir -v "${SHARED_DERIVED_DATA_PATH}"
+
     log "Recreating shared example harness directory: ${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
     rm -rf "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
     mkdir -v "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
@@ -40,20 +45,21 @@ for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name 
     log "Updating mtime of example contents..."
     find "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" -print0 | xargs -0 -n1 touch -m
 
+    # There is no CLI to modify dependencies, revert to sed
+    log "Re-overriding dependency in ${EXAMPLE_PACKAGE_NAME} to use ${PACKAGE_PATH}"
+    PBXPROJ_PATH=$(find $SHARED_EXAMPLE_HARNESS_PACKAGE_PATH -name "project.pbxproj" -type f -maxdepth 2)
+    sed -i '' "s|${ORIGINAL_LOCAL_DEPENDENCY_PATH}|${PACKAGE_PATH}|g" "$PBXPROJ_PATH"
+
+    PROJECT_PATH=$(find $SHARED_EXAMPLE_HARNESS_PACKAGE_PATH -name "*.xcodeproj" -type d -maxdepth 1)
+
     log "Building example app: ${EXAMPLE_PACKAGE_NAME}"
-    ( 
-        cd "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
-
-        # There is no CLI to modify dependencies, revert to sed
-        PBXPROJ=$(find . -name "project.pbxproj" -type f -maxdepth 2)
-        sed -i '' "s|${ORIGINAL_LOCAL_DEPENDENCY_PATH}|${PACKAGE_PATH}|g" "$PBXPROJ"
-
-        "${XCODEBUILD_BIN}" build \
-            -scheme "${EXAMPLE_PACKAGE_NAME}" \
-            -destination "${XCODEBUILD_DESTINATION}" \
-            -clonedSourcePackagesDirPath "${SHARED_PACKAGE_CACHE_PATH}" \
-            -skipPackageUpdates \
-            -derivedDataPath "${SHARED_PACKAGE_SCRATCH_PATH}"
-        log "✅ Successfully built the example app ${EXAMPLE_PACKAGE_NAME}."
-    )
+    "${XCODEBUILD_BIN}" build \
+        -project "${PROJECT_PATH}" \
+        -scheme "${EXAMPLE_PACKAGE_NAME}" \
+        -destination "${XCODEBUILD_DESTINATION}" \
+        -packageCachePath "${SHARED_PACKAGE_CACHE_PATH}" \
+        -clonedSourcePackagesDirPath ${SHARED_CLONED_SOURCES_PATH} \
+        -skipPackageUpdates \
+        -derivedDataPath "${SHARED_DERIVED_DATA_PATH}"
+    log "✅ Successfully built the example app ${EXAMPLE_PACKAGE_NAME}."
 done

--- a/Scripts/test-xcode-examples.sh
+++ b/Scripts/test-xcode-examples.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+log "Checking required executables..."
+XCODEBUILD_BIN=${XCODEBUILD_BIN:-$(command -v xcodebuild || xcrun -f swift)} || fatal "XCODEBUILD_BIN unset and no xcodebuild on PATH"
+
+CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
+TMP_DIR=$(/usr/bin/mktemp -d -p "${TMPDIR-/tmp}" "$(basename "$0").XXXXXXXXXX")
+
+PACKAGE_PATH=${PACKAGE_PATH:-${REPO_ROOT}}
+EXAMPLES_PACKAGE_PATH="${PACKAGE_PATH}/Examples"
+SHARED_EXAMPLE_HARNESS_PACKAGE_PATH="${TMP_DIR}/example-harness"
+SHARED_DERIVED_DATA_PATH="${TMP_DIR}/example-derived-data"
+SHARED_PACKAGE_CACHE_PATH="${TMP_DIR}/example-cache"
+SHARED_CLONED_SOURCES_PATH="${TMP_DIR}/example-cloned-sources"
+XCODEBUILD_DESTINATION=${XCODEBUILD_DESTINATION:-"generic/platform=macOS"}
+ORIGINAL_LOCAL_DEPENDENCY_PATH=${ORIGINAL_LOCAL_DEPENDENCY_PATH:-"../../../swift-configuration"}
+
+for EXAMPLE_PACKAGE_PATH in $(find "${EXAMPLES_PACKAGE_PATH}" -maxdepth 2 -name '*.xcodeproj' -type d -print0 | xargs -0 dirname | sort); do
+
+    EXAMPLE_PACKAGE_NAME="$(basename "${EXAMPLE_PACKAGE_PATH}")"
+
+    if [[ "${SINGLE_EXAMPLE_PACKAGE:-${EXAMPLE_PACKAGE_NAME}}" != "${EXAMPLE_PACKAGE_NAME}" ]]; then
+        log "Skipping example: ${EXAMPLE_PACKAGE_NAME}"
+        continue
+    fi
+
+    log "Recreating shared derived data directory: ${SHARED_DERIVED_DATA_PATH}"
+    rm -rf "${SHARED_DERIVED_DATA_PATH}"
+    mkdir -v "${SHARED_DERIVED_DATA_PATH}"
+
+    log "Recreating shared example harness directory: ${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+    rm -rf "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+    mkdir -v "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+
+    log "Copying example contents from ${EXAMPLE_PACKAGE_NAME} to ${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}"
+    git archive HEAD "${EXAMPLE_PACKAGE_PATH}" --format tar | tar -C "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" -xvf- --strip-components 2
+
+    # GNU tar has --touch, but BSD tar does not, so we'll use touch directly.
+    log "Updating mtime of example contents..."
+    find "${SHARED_EXAMPLE_HARNESS_PACKAGE_PATH}" -print0 | xargs -0 -n1 touch -m
+
+    # There is no CLI to modify dependencies, revert to sed
+    log "Re-overriding dependency in ${EXAMPLE_PACKAGE_NAME} to use ${PACKAGE_PATH}"
+    PBXPROJ_PATH=$(find $SHARED_EXAMPLE_HARNESS_PACKAGE_PATH -name "project.pbxproj" -type f -maxdepth 2)
+    sed -i '' "s|${ORIGINAL_LOCAL_DEPENDENCY_PATH}|${PACKAGE_PATH}|g" "$PBXPROJ_PATH"
+
+    PROJECT_PATH=$(find $SHARED_EXAMPLE_HARNESS_PACKAGE_PATH -name "*.xcodeproj" -type d -maxdepth 1)
+
+    log "Building example app: ${EXAMPLE_PACKAGE_NAME}"
+    "${XCODEBUILD_BIN}" build \
+        -project "${PROJECT_PATH}" \
+        -scheme "${EXAMPLE_PACKAGE_NAME}" \
+        -destination "${XCODEBUILD_DESTINATION}" \
+        -packageCachePath "${SHARED_PACKAGE_CACHE_PATH}" \
+        -clonedSourcePackagesDirPath ${SHARED_CLONED_SOURCES_PATH} \
+        -skipPackageUpdates \
+        -derivedDataPath "${SHARED_DERIVED_DATA_PATH}"
+    log "✅ Successfully built the example app ${EXAMPLE_PACKAGE_NAME}."
+done


### PR DESCRIPTION
### Motivation

Addresses #34 - Add a simple multi-platform app that demonstrates basic usage of `swift-configuration` in Xcode.

### Modifications

Add a new example, `Examples/HelloWorldAppExample` (heavily inspired by `Examples/hello-world-cli-example`), a script to build any `.xcodeproj` examples, and a pipeline step that runs this across all Apple platforms.

### Result

Examples now cover Xcode projects, which should help iOS developers to get started. By adding a script `Scripts/test-xcode-examples.sh` it's easy to add additional examples apps in the future.

### Test Plan

The added pipeline steps verify that the example app compiles. Manual tests where the app is run on simulator devices verify that the expected text is shown.