### PR TITLE
Enable Swift 6.3 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_6_1_enabled: false
       linux_nightly_next_enabled: false
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,7 @@ jobs:
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_6_1_enabled: false
       linux_nightly_next_enabled: false
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"

--- a/Benchmarks/Thresholds/6.3/Benchmarks.ConfigReader_InMemoryProvider_found_fetchInt.p90.json
+++ b/Benchmarks/Thresholds/6.3/Benchmarks.ConfigReader_InMemoryProvider_found_fetchInt.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 3009
+}

--- a/Benchmarks/Thresholds/6.3/Benchmarks.ConfigReader_InMemoryProvider_found_int.p90.json
+++ b/Benchmarks/Thresholds/6.3/Benchmarks.ConfigReader_InMemoryProvider_found_int.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 3008
+}

--- a/Benchmarks/Thresholds/6.3/Benchmarks.ConfigReader_InMemoryProvider_found_string.p90.json
+++ b/Benchmarks/Thresholds/6.3/Benchmarks.ConfigReader_InMemoryProvider_found_string.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 3008
+}

--- a/Benchmarks/Thresholds/6.3/Benchmarks.ConfigReader_InMemoryProvider_notFound_string.p90.json
+++ b/Benchmarks/Thresholds/6.3/Benchmarks.ConfigReader_InMemoryProvider_notFound_string.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 3005
+}

--- a/Benchmarks/Thresholds/6.3/Benchmarks.EnvironmentVariablesProvider_found_string.p90.json
+++ b/Benchmarks/Thresholds/6.3/Benchmarks.EnvironmentVariablesProvider_found_string.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 3005
+}

--- a/Benchmarks/Thresholds/6.3/Benchmarks.EnvironmentVariablesProvider_notFound_string.p90.json
+++ b/Benchmarks/Thresholds/6.3/Benchmarks.EnvironmentVariablesProvider_notFound_string.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 3002
+}


### PR DESCRIPTION
Motivation:

Swift 6.3 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.3 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
