### PR TITLE
docs: document metrics emitted by ReloadingFileProvider

### DIFF
--- a/Sources/Configuration/Documentation.docc/Guides/Using-reloading-providers.md
+++ b/Sources/Configuration/Documentation.docc/Guides/Using-reloading-providers.md
@@ -168,6 +168,28 @@ let jsonProvider = try await ReloadingFileProvider<JSONSnapshot>(
 )
 ```
 
+#### Observability metrics
+
+``ReloadingFileProvider`` emits metrics through [`swift-metrics`](https://github.com/apple/swift-metrics). By default, the provider uses the process-wide `MetricsSystem.factory`, so whichever backend you bootstrap (for example, `StatsdMetrics` or `PrometheusMetrics`) receives its counters and gauges. Pass an explicit `metrics:` argument to the initializer when you want to redirect them — for example, to an isolated registry in tests:
+
+```swift
+let provider = try await ReloadingFileProvider<JSONSnapshot>(
+    filePath: "/etc/config.json",
+    metrics: myTestMetricsFactory
+)
+```
+
+Every metric label starts with a prefix derived from the provider name, lowercased (for example, `reloadingfileprovider_poll_ticks_total`):
+
+| Metric                         | Type    | Meaning                                                                                                                 |
+|--------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------|
+| `<prefix>_poll_ticks_total`    | Counter | Increments on every polling-cycle timestamp check, whether or not a reload was needed.                                  |
+| `<prefix>_poll_errors_total`   | Counter | Increments when the polling timestamp check fails (file-system error, permission issue, and so on).                     |
+| `<prefix>_reloads_total`       | Counter | Increments each time the provider successfully reloads and parses the configuration file after detecting a change.     |
+| `<prefix>_reload_errors_total` | Counter | Increments when a reload fails (parse error, file-system error, and so on).                                             |
+| `<prefix>_file_size_bytes`     | Gauge   | Current on-disk size of the configuration file in bytes, refreshed after every successful reload.                       |
+| `<prefix>_watchers_active`     | Gauge   | Total number of active value and snapshot watchers currently registered with the provider.                              |
+
 ### Migration from static providers
 
 1. **Replace initialization**:


### PR DESCRIPTION
### Motivation

Refs #27 ("Document the emitted metrics for each long-running provider"). `ReloadingFileProvider` is the only provider today that publishes via `swift-metrics` (it takes an optional `metrics:` factory, defaulting to `MetricsSystem.factory`), so users have no way to discover the counters and gauges it emits short of reading `ReloadingFileProviderMetrics`.

### Modifications

Adds a new **Observability metrics** subsection inside the *Advanced features* block of `Sources/Configuration/Documentation.docc/Guides/Using-reloading-providers.md`. The new section covers:

- Where the `MetricsFactory` comes from (process-wide `MetricsSystem.factory` by default) and how to redirect it via the `metrics:` initializer argument for tests or isolated registries.
- Each of the six metrics `ReloadingFileProviderMetrics` publishes in a single table: the four counters (`<prefix>_poll_ticks_total`, `<prefix>_poll_errors_total`, `<prefix>_reloads_total`, `<prefix>_reload_errors_total`) and two gauges (`<prefix>_file_size_bytes`, `<prefix>_watchers_active`). The `<prefix>` convention matches the provider-name-lowercased label scheme used in `ReloadingFileProviderMetrics.init(factory:providerName:)`.

Wording is derived from the internal doc comments on each metric so the user-facing guide and the implementation stay aligned if one is later updated.

### Result

Users bootstrapping a metrics backend can dashboard/alert on the provider's polling and reload behaviour without reading the Swift source. Implementers writing additional long-running providers have a template to extend in the same guide.

### Test Plan

- Docs-only change; no behavioural impact, no source-file edits.
- Ran `PROJECT_NAME="SwiftConfiguration" check-license-header.sh` (the same script the swiftlang soundness workflow invokes) — passes with "Found no files with missing license header."
- Spot-checked the metric labels and types against `Sources/Configuration/Providers/Files/ReloadingFileProviderMetrics.swift` to make sure the table lines up with the actual `Counter` / `Gauge` declarations and the `prefix = providerName.lowercased()` construction.