### PR TITLE
update .spi build to request 6.3 and extended HTML output

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,7 +1,9 @@
 version: 1
 builder:
   configs:
-    - swift_version: '6.2'
+    - swift_version: '6.3'
       documentation_targets:
         - Configuration
         - ConfigurationTesting
+      custom_documentation_parameters:
+        - '--experimental-transform-for-static-hosting-with-content'


### PR DESCRIPTION
This updates the instructions for Swift Package Index to explicitly use Swift 6.3 for the documentation build, as well as enabling the additional experimental feature `--experimental-transform-for-static-hosting-with-content`, which embeds HTML content to (hopefully) make it easier to get improved SEO results for the documentation content.