### PR TITLE
Migrate macOS CI to Swift version inputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
       runner_pool: nightly
       build_scheme: swift-configuration-Package
-      swift_6_1_enabled: true
+      swift_6_1_enabled: false
       swift_6_2_enabled: true
       swift_6_3_enabled: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,9 @@ jobs:
       env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
       runner_pool: nightly
       build_scheme: swift-configuration-Package
-      xcode_16_2_enabled: false
-      xcode_16_3_enabled: false
-      xcode_16_4_enabled: false
+      swift_6_1_enabled: true
+      swift_6_2_enabled: true
+      swift_6_3_enabled: true
 
   release-builds:
     name: Release builds

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -67,9 +67,9 @@ jobs:
       env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
       runner_pool: general
       build_scheme: swift-configuration-Package
-      xcode_16_2_enabled: false
-      xcode_16_3_enabled: false
-      xcode_16_4_enabled: false
+      swift_6_1_enabled: true
+      swift_6_2_enabled: true
+      swift_6_3_enabled: true
 
   release-builds:
     name: Release builds

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -67,7 +67,7 @@ jobs:
       env_vars: '{"ENABLE_ALL_TRAITS":"1"}'
       runner_pool: general
       build_scheme: swift-configuration-Package
-      swift_6_1_enabled: true
+      swift_6_1_enabled: false
       swift_6_2_enabled: true
       swift_6_3_enabled: true
 


### PR DESCRIPTION
### Motivation

* The shared `macos_tests.yml` workflow supports requesting Xcodes by Swift version rather than directly specifying Xcode version, with symlinks on the runners owning the mapping.
* Specifying Swift version directly with floating mappings more directly expresses the intent of the library support window.
* I intend to disable Xcode version inputs by default imminently so we can just remove those for now.

### Modifications

* Replace `xcode_16_2/16_3/16_4_enabled: false` with `swift_6_1/6_2/6_3_enabled: true` in both `main.yml` and `pull_request.yml`.

### Result

* macOS CI requests toolchains by Swift version, decoupling the workflow from specific Xcode release names.
