### PR TITLE
Migrate `nightly_6_*` inputs to `nightly_next`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,17 +20,16 @@ jobs:
       linux_6_1_enabled: false
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_1_enabled: false
       linux_nightly_next_enabled: false
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
       # Windows is disabled, blocked on Swift Service Lifecycle Windows support: https://github.com/swift-server/swift-service-lifecycle/issues/213
       windows_6_0_enabled: false
       windows_6_1_enabled: false
-      windows_nightly_6_1_enabled: false
+      windows_nightly_next_enabled: false
       windows_nightly_main_enabled: false
       windows_6_1_arguments_override: "--enable-all-traits --explicit-target-dependency-import-check error"
-      windows_nightly_6_1_arguments_override: "--enable-all-traits --explicit-target-dependency-import-check error"
+      windows_nightly_next_arguments_override: "--enable-all-traits --explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--enable-all-traits --explicit-target-dependency-import-check error"
 
   static-sdk:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,17 +27,16 @@ jobs:
       linux_6_1_enabled: false
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_1_enabled: false
       linux_nightly_next_enabled: false
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
       # Windows is disabled, blocked on Swift Service Lifecycle Windows support: https://github.com/swift-server/swift-service-lifecycle/issues/213
       windows_6_0_enabled: false
       windows_6_1_enabled: false
-      windows_nightly_6_1_enabled: false
+      windows_nightly_next_enabled: false
       windows_nightly_main_enabled: false
       windows_6_1_arguments_override: "--enable-all-traits --explicit-target-dependency-import-check error"
-      windows_nightly_6_1_arguments_override: "--enable-all-traits --explicit-target-dependency-import-check error"
+      windows_nightly_next_arguments_override: "--enable-all-traits --explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--enable-all-traits --explicit-target-dependency-import-check error"
 
   static-sdk:


### PR DESCRIPTION
Motivation

* The `linux_nightly_6_0/6_1` and `windows_nightly_6_1` inputs in the
  shared workflows are deprecated. `nightly_6_1` is aliased to
  `nightly_next` and `nightly_6_0` no longer runs.

Modifications

* Rename all `nightly_6_*` references to `nightly_next`.

Result

* Uses the canonical input names, no longer references deprecated
  inputs.
