### PR TITLE
Update API docs with preconditions

### DIFF
--- a/Sources/Configuration/AccessReporter.swift
+++ b/Sources/Configuration/AccessReporter.swift
@@ -216,7 +216,7 @@ public struct BroadcastingAccessReporter: Sendable {
     /// Creates a new broadcasting access reporter.
     ///
     /// - Parameter upstreams: The reporters that will receive forwarded events.
-    /// - Precondition: upstreams must not be empty.
+    /// - Precondition: `upstreams` must not be empty.
     public init(upstreams: [any AccessReporter]) {
         precondition(!upstreams.isEmpty, "BroadcastingAccessReporter upstreams cannot be empty")
         self.upstreams = upstreams

--- a/Sources/Configuration/AccessReporter.swift
+++ b/Sources/Configuration/AccessReporter.swift
@@ -216,6 +216,7 @@ public struct BroadcastingAccessReporter: Sendable {
     /// Creates a new broadcasting access reporter.
     ///
     /// - Parameter upstreams: The reporters that will receive forwarded events.
+    /// - Precondition: upstreams must not be empty.
     public init(upstreams: [any AccessReporter]) {
         precondition(!upstreams.isEmpty, "BroadcastingAccessReporter upstreams cannot be empty")
         self.upstreams = upstreams

--- a/Sources/Configuration/ConfigReader.swift
+++ b/Sources/Configuration/ConfigReader.swift
@@ -272,7 +272,7 @@ public struct ConfigReader: Sendable {
     /// - Parameters:
     ///   - providers: The configuration providers, queried in order until a value is found.
     ///   - accessReporter: The reporter for configuration access events.
-    /// - Precondition: providers must not be empty.
+    /// - Precondition: `providers` must not be empty.
     public init(
         providers: [any ConfigProvider],
         accessReporter: (any AccessReporter)? = nil

--- a/Sources/Configuration/ConfigReader.swift
+++ b/Sources/Configuration/ConfigReader.swift
@@ -272,10 +272,12 @@ public struct ConfigReader: Sendable {
     /// - Parameters:
     ///   - providers: The configuration providers, queried in order until a value is found.
     ///   - accessReporter: The reporter for configuration access events.
+    /// - Precondition: providers must not be empty.
     public init(
         providers: [any ConfigProvider],
         accessReporter: (any AccessReporter)? = nil
     ) {
+        precondition(!providers.isEmpty, "ConfigProvider requires at least one provider")
         var reporter = accessReporter as (any AccessReporter)?
         do {
             if let fileReporter = try FileAccessLogger.detectedFromEnvironment() {

--- a/Sources/Configuration/MultiProvider.swift
+++ b/Sources/Configuration/MultiProvider.swift
@@ -68,6 +68,7 @@ internal struct MultiProvider: Sendable {
 
     /// Creates a new multi-provider with the specified nested providers.
     /// - Parameter providers: The nested providers in precedence order (first provider has highest precedence).
+    /// - Precondition: providers must not be empty.
     init(providers: [any ConfigProvider]) {
         precondition(!providers.isEmpty, "MultiProvider requires at least one nested provider")
         self.storage = .init(providers: providers)

--- a/Sources/Configuration/MultiProvider.swift
+++ b/Sources/Configuration/MultiProvider.swift
@@ -68,7 +68,7 @@ internal struct MultiProvider: Sendable {
 
     /// Creates a new multi-provider with the specified nested providers.
     /// - Parameter providers: The nested providers in precedence order (first provider has highest precedence).
-    /// - Precondition: providers must not be empty.
+    /// - Precondition: `providers` must not be empty.
     init(providers: [any ConfigProvider]) {
         precondition(!providers.isEmpty, "MultiProvider requires at least one nested provider")
         self.storage = .init(providers: providers)


### PR DESCRIPTION
### Motivation

I expected `ConfigReader(providers: [])` to be equivalent to an empty config - however, the entire program crashed unexpectedly. This PR adds the precondition to the API docs so this behavior is clearly documented.

A separate discussion of "should `ConfigReader(providers: [])` be valid?" may be warranted but is beyond the scope of this PR. The purpose of the PR is to simply make existing behavior more clear in the docs.

### Modifications

Adds precondition docs to public API.

Also adds a precondition to `ConfigReader`. This isn't a behavior change per se, as it calls `MultiProvider(providers: providers)`, which has an equivalent precondition. But this makes the error message clearer and also preserves API behavior even if `MultiProvider` changes in the future.

### Result

The API docs will explicitly specify preconditions which, if not met, will cause crashes.

### Test Plan

Manually ran the command to generate docs locally to see the changes.
