### PR TITLE
Add CustomStringConvertible/CustomDebugStringConvertible conformances to public APIs

### DIFF
--- a/Sources/Configuration/AccessReporter.swift
+++ b/Sources/Configuration/AccessReporter.swift
@@ -51,7 +51,7 @@ public struct AccessEvent: Sendable {
     /// source location, and timestamp.
     public struct Metadata: Sendable {
 
-        /// The source code location where a configuration access occurs.
+  2     /// The source code location where a configuration access occurs.
         ///
         /// Captures the file identifier and line number for debugging and auditing purposes.
         public struct SourceLocation: Sendable, CustomStringConvertible {
@@ -232,11 +232,6 @@ extension BroadcastingAccessReporter: AccessReporter {
     }
 }
 
-@available(Configuration 1.0, *)
-extension AccessEvent.Metadata.SourceLocation: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}
 
 @available(Configuration 1.0, *)
 extension AccessEvent.Metadata: CustomStringConvertible {
@@ -261,11 +256,6 @@ extension AccessEvent.ProviderResult: CustomStringConvertible {
     }
 }
 
-@available(Configuration 1.0, *)
-extension AccessEvent.ProviderResult: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}
 
 @available(Configuration 1.0, *)
 extension AccessEvent: CustomStringConvertible {
@@ -296,8 +286,3 @@ extension BroadcastingAccessReporter: CustomStringConvertible {
     public var description: String { "BroadcastingAccessReporter[\(upstreams.count) reporters]" }
 }
 
-@available(Configuration 1.0, *)
-extension BroadcastingAccessReporter: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}

--- a/Sources/Configuration/AccessReporter.swift
+++ b/Sources/Configuration/AccessReporter.swift
@@ -231,3 +231,79 @@ extension BroadcastingAccessReporter: AccessReporter {
         }
     }
 }
+
+@available(Configuration 1.0, *)
+extension AccessEvent.Metadata.SourceLocation: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String { "\(file):\(line)" }
+}
+
+@available(Configuration 1.0, *)
+extension AccessEvent.Metadata.SourceLocation: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}
+
+@available(Configuration 1.0, *)
+extension AccessEvent.Metadata: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String { "\(accessKind.rawValue) \(key) as \(valueType)" }
+}
+
+@available(Configuration 1.0, *)
+extension AccessEvent.Metadata: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { "\(accessKind.rawValue) \(key) as \(valueType) @ \(sourceLocation)" }
+}
+
+@available(Configuration 1.0, *)
+extension AccessEvent.ProviderResult: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String {
+        switch result {
+            case .success(let lookup): return "\(providerName): \(lookup)"
+            case .failure(let error): return "\(providerName): error(\(error))"
+        }
+    }
+}
+
+@available(Configuration 1.0, *)
+extension AccessEvent.ProviderResult: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}
+
+@available(Configuration 1.0, *)
+extension AccessEvent: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String {
+        switch result {
+            case .success(let value): return "AccessEvent[\(metadata), result: \(value?.description ?? "(not found)")]"
+            case .failure(let error): return "AccessEvent[\(metadata), error: \(error)]"
+        }
+    }
+}
+
+@available(Configuration 1.0, *)
+extension AccessEvent: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String {
+        let providerSummary = providerResults.map(\.description).joined(separator: ", ")
+        switch result {
+            case .success(let value): return "AccessEvent[\(metadata.debugDescription), providers: [\(providerSummary)], result: \(value?.description ?? "(not found)")]"
+            case .failure(let error): return "AccessEvent[\(metadata.debugDescription), providers: [\(providerSummary)], error: \(error)]"
+        }
+    }
+}
+
+@available(Configuration 1.0, *)
+extension BroadcastingAccessReporter: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String { "BroadcastingAccessReporter[\(upstreams.count) reporters]" }
+}
+
+@available(Configuration 1.0, *)
+extension BroadcastingAccessReporter: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}

--- a/Sources/Configuration/AccessReporter.swift
+++ b/Sources/Configuration/AccessReporter.swift
@@ -233,12 +233,6 @@ extension BroadcastingAccessReporter: AccessReporter {
 }
 
 @available(Configuration 1.0, *)
-extension AccessEvent.Metadata.SourceLocation: CustomStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var description: String { "\(file):\(line)" }
-}
-
-@available(Configuration 1.0, *)
 extension AccessEvent.Metadata.SourceLocation: CustomDebugStringConvertible {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var debugDescription: String { description }

--- a/Sources/Configuration/ConfigContext.swift
+++ b/Sources/Configuration/ConfigContext.swift
@@ -106,3 +106,16 @@ extension [String: ConfigContextValue] {
             .joined(separator: ";")
     }
 }
+
+@available(Configuration 1.0, *)
+extension ConfigContextValue: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String {
+        switch self {
+            case .string(let value): return ".string(\"\(value)\")"
+            case .int(let value): return ".int(\(value))"
+            case .double(let value): return ".double(\(value))"
+            case .bool(let value): return ".bool(\(value))"
+        }
+    }
+}

--- a/Sources/Configuration/ConfigKey.swift
+++ b/Sources/Configuration/ConfigKey.swift
@@ -260,3 +260,15 @@ extension AbsoluteConfigKey: ExpressibleByArrayLiteral {
         self.init(elements)
     }
 }
+
+@available(Configuration 1.0, *)
+extension ConfigKey: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}
+
+@available(Configuration 1.0, *)
+extension AbsoluteConfigKey: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}

--- a/Sources/Configuration/ConfigKey.swift
+++ b/Sources/Configuration/ConfigKey.swift
@@ -261,14 +261,4 @@ extension AbsoluteConfigKey: ExpressibleByArrayLiteral {
     }
 }
 
-@available(Configuration 1.0, *)
-extension ConfigKey: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}
 
-@available(Configuration 1.0, *)
-extension AbsoluteConfigKey: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}

--- a/Sources/Configuration/ConfigProvider.swift
+++ b/Sources/Configuration/ConfigProvider.swift
@@ -557,24 +557,14 @@ extension ConfigContent: ExpressibleByBooleanLiteral {
 
 @available(Configuration 1.0, *)
 extension LookupResult: CustomStringConvertible {
-        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-        public var description: String {
-                    if let value {
-                                    return "[key: \(encodedKey), \(value)]"
-                    } else {
-                                    return "[key: \(encodedKey), (not found)]"
-                    }
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String {
+        if let value {
+            return "[key: \(encodedKey), \(value)]"
+        } else {
+            return "[key: \(encodedKey), (not found)]"
         }
+    }
 }
 
-@available(Configuration 1.0, *)
-extension LookupResult: CustomDebugStringConvertible {
-        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-        public var debugDescription: String { description }
-}
 
-@available(Configuration 1.0, *)
-extension ConfigValue: CustomDebugStringConvertible {
-        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-        public var debugDescription: String { description }
-}

--- a/Sources/Configuration/ConfigProvider.swift
+++ b/Sources/Configuration/ConfigProvider.swift
@@ -554,3 +554,27 @@ extension ConfigContent: ExpressibleByBooleanLiteral {
         self = .bool(value)
     }
 }
+
+@available(Configuration 1.0, *)
+extension LookupResult: CustomStringConvertible {
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public var description: String {
+                    if let value {
+                                    return "[key: \(encodedKey), \(value)]"
+                    } else {
+                                    return "[key: \(encodedKey), (not found)]"
+                    }
+        }
+}
+
+@available(Configuration 1.0, *)
+extension LookupResult: CustomDebugStringConvertible {
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public var debugDescription: String { description }
+}
+
+@available(Configuration 1.0, *)
+extension ConfigValue: CustomDebugStringConvertible {
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        public var debugDescription: String { description }
+}

--- a/Sources/Configuration/ConfigReader.swift
+++ b/Sources/Configuration/ConfigReader.swift
@@ -389,3 +389,18 @@ package enum ConfigError: Error, CustomStringConvertible, Equatable {
         }
     }
 }
+
+@available(Configuration 1.0, *)
+extension ConfigReader: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String {
+        if let keyPrefix { return "ConfigReader[prefix: \(keyPrefix), \(provider)]" }
+        return "ConfigReader[\(provider)]"
+    }
+}
+
+@available(Configuration 1.0, *)
+extension ConfigReader: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}

--- a/Sources/Configuration/ConfigReader.swift
+++ b/Sources/Configuration/ConfigReader.swift
@@ -399,8 +399,3 @@ extension ConfigReader: CustomStringConvertible {
     }
 }
 
-@available(Configuration 1.0, *)
-extension ConfigReader: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}

--- a/Sources/Configuration/ConfigSnapshotReader.swift
+++ b/Sources/Configuration/ConfigSnapshotReader.swift
@@ -565,3 +565,19 @@ extension ConfigSnapshotReader {
         .intArray(values.map(\.rawValue))
     }
 }
+
+@available(Configuration 1.0, *)
+extension ConfigSnapshotReader: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String {
+        let providerNames = storage.snapshot.snapshots.map(\.providerName).joined(separator: ", ")
+        if let keyPrefix { return "ConfigSnapshotReader[prefix: \(keyPrefix), of: \(providerNames)]" }
+        return "ConfigSnapshotReader[of: \(providerNames)]"
+    }
+}
+
+@available(Configuration 1.0, *)
+extension ConfigSnapshotReader: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}

--- a/Sources/Configuration/ConfigSnapshotReader.swift
+++ b/Sources/Configuration/ConfigSnapshotReader.swift
@@ -576,8 +576,3 @@ extension ConfigSnapshotReader: CustomStringConvertible {
     }
 }
 
-@available(Configuration 1.0, *)
-extension ConfigSnapshotReader: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}

--- a/Sources/Configuration/SecretsSpecifier.swift
+++ b/Sources/Configuration/SecretsSpecifier.swift
@@ -151,8 +151,3 @@ extension SecretsSpecifier: CustomStringConvertible {
     }
 }
 
-@available(Configuration 1.0, *)
-extension SecretsSpecifier: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}

--- a/Sources/Configuration/SecretsSpecifier.swift
+++ b/Sources/Configuration/SecretsSpecifier.swift
@@ -137,3 +137,22 @@ extension SecretsSpecifier {
         return isSecret
     }
 }
+
+@available(Configuration 1.0, *)
+extension SecretsSpecifier: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String {
+        switch self {
+            case .all: return "all"
+            case .none: return "none"
+            case .specific(let keys): return "specific(\(keys.count) keys)"
+            case .dynamic: return "dynamic"
+        }
+    }
+}
+
+@available(Configuration 1.0, *)
+extension SecretsSpecifier: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}

--- a/Sources/Configuration/Utilities/AsyncSequences.swift
+++ b/Sources/Configuration/Utilities/AsyncSequences.swift
@@ -165,8 +165,3 @@ extension ConfigUpdatesAsyncSequence: CustomStringConvertible {
     public var description: String { "ConfigUpdatesAsyncSequence" }
 }
 
-@available(Configuration 1.0, *)
-extension ConfigUpdatesAsyncSequence: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}

--- a/Sources/Configuration/Utilities/AsyncSequences.swift
+++ b/Sources/Configuration/Utilities/AsyncSequences.swift
@@ -158,3 +158,15 @@ extension MapThrowingAsyncSequence: AsyncSequence {
         }
     }
 }
+
+@available(Configuration 1.0, *)
+extension ConfigUpdatesAsyncSequence: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String { "ConfigUpdatesAsyncSequence" }
+}
+
+@available(Configuration 1.0, *)
+extension ConfigUpdatesAsyncSequence: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}

--- a/Sources/Configuration/ValueCoders/ConfigBytesFromStringDecoder.swift
+++ b/Sources/Configuration/ValueCoders/ConfigBytesFromStringDecoder.swift
@@ -109,7 +109,7 @@ extension ConfigBytesFromHexStringDecoder: ConfigBytesFromStringDecoder {
         while index < value.endIndex {
             let nextIndex = value.index(index, offsetBy: 2)
             let byteString = value[index..<nextIndex]
-            guard let byte = UInt8(byteString, radix: 16) else {
+            guard let byte = UInt8(byteString, radiz: 16) else {
                 return nil
             }
             bytes.append(byte)
@@ -132,11 +132,6 @@ extension ConfigBytesFromBase64StringDecoder: CustomStringConvertible {
     public var description: String { "ConfigBytesFromBase64StringDecoder" }
 }
 
-@available(Configuration 1.0, *)
-extension ConfigBytesFromBase64StringDecoder: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}
 
 @available(Configuration 1.0, *)
 extension ConfigBytesFromHexStringDecoder: CustomStringConvertible {
@@ -144,8 +139,3 @@ extension ConfigBytesFromHexStringDecoder: CustomStringConvertible {
     public var description: String { "ConfigBytesFromHexStringDecoder" }
 }
 
-@available(Configuration 1.0, *)
-extension ConfigBytesFromHexStringDecoder: CustomDebugStringConvertible {
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    public var debugDescription: String { description }
-}

--- a/Sources/Configuration/ValueCoders/ConfigBytesFromStringDecoder.swift
+++ b/Sources/Configuration/ValueCoders/ConfigBytesFromStringDecoder.swift
@@ -125,3 +125,27 @@ extension ConfigBytesFromStringDecoder where Self == ConfigBytesFromHexStringDec
     /// A decoder that interprets string values as hexadecimal-encoded data.
     public static var hex: Self { .init() }
 }
+
+@available(Configuration 1.0, *)
+extension ConfigBytesFromBase64StringDecoder: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String { "ConfigBytesFromBase64StringDecoder" }
+}
+
+@available(Configuration 1.0, *)
+extension ConfigBytesFromBase64StringDecoder: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}
+
+@available(Configuration 1.0, *)
+extension ConfigBytesFromHexStringDecoder: CustomStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var description: String { "ConfigBytesFromHexStringDecoder" }
+}
+
+@available(Configuration 1.0, *)
+extension ConfigBytesFromHexStringDecoder: CustomDebugStringConvertible {
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var debugDescription: String { description }
+}

--- a/Tests/ConfigurationTests/CustomStringConvertibleTests.swift
+++ b/Tests/ConfigurationTests/CustomStringConvertibleTests.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+@testable import Configuration
+
+struct CustomStringConvertibleTests {
+
+  @available(Configuration 1.0, *)
+  @Test func configKeyDebugDescription() {
+    let key = ConfigKey(["http", "timeout"])
+    #expect(key.description == "http.timeout")
+    #expect(key.debugDescription == "http.timeout")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func absoluteConfigKeyDebugDescription() {
+    let key = AbsoluteConfigKey(["app", "feature", "enabled"])
+    #expect(key.description == "app.feature.enabled")
+    #expect(key.debugDescription == "app.feature.enabled")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configContextValueIntDebugDescription() {
+    #expect(ConfigContextValue.int(8080).debugDescription == ".int(8080)")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configContextValueDoubleDebugDescription() {
+    #expect(ConfigContextValue.double(1.5).debugDescription == ".double(1.5)")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configContextValueBoolDebugDescription() {
+    #expect(ConfigContextValue.bool(true).debugDescription == ".bool(true)")
+    #expect(ConfigContextValue.bool(false).debugDescription == ".bool(false)")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func sourceLocationDescription() {
+    let loc = AccessEvent.Metadata.SourceLocation(fileID: "MyModule/Config.swift", line: 99)
+    #expect(loc.description == "MyModule/Config.swift:99")
+    #expect(loc.debugDescription == "MyModule/Config.swift:99")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func secretsSpecifierAllDescription() {
+    let specifier: SecretsSpecifier<String, String> = .all
+    #expect(specifier.description == "all")
+    #expect(specifier.debugDescription == "all")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func secretsSpecifierNoneDescription() {
+    let specifier: SecretsSpecifier<String, String> = .none
+    #expect(specifier.description == "none")
+    #expect(specifier.debugDescription == "none")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func secretsSpecifierSpecificDescription() {
+    let specifier: SecretsSpecifier<String, String> = .specific(["apiKey", "token", "password"])
+    #expect(specifier.description == "specific(3 keys)")
+    #expect(specifier.debugDescription == "specific(3 keys)")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func secretsSpecifierDynamicDescription() {
+    let specifier: SecretsSpecifier<String, String> = .dynamic(@Sendable { _, _ in true })
+    #expect(specifier.description == "dynamic")
+    #expect(specifier.debugDescription == "dynamic")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configBytesFromBase64StringDecoderDescription() {
+    let decoder = ConfigBytesFromBase64StringDecoder()
+    #expect(decoder.description == "ConfigBytesFromBase64StringDecoder")
+    #expect(decoder.debugDescription == "ConfigBytesFromBase64StringDecoder")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configBytesFromHexStringDecoderDescription() {
+    let decoder = ConfigBytesFromHexStringDecoder()
+    #expect(decoder.description == "ConfigBytesFromHexStringDecoder")
+    #expect(decoder.debugDescription == "ConfigBytesFromHexStringDecoder")
+  }
+}

--- a/Tests/ConfigurationTests/CustomStringConvertibleTests.swift
+++ b/Tests/ConfigurationTests/CustomStringConvertibleTests.swift
@@ -77,7 +77,8 @@ struct CustomStringConvertibleTests {
 
   @available(Configuration 1.0, *)
   @Test func secretsSpecifierDynamicDescription() {
-    let specifier: SecretsSpecifier<String, String> = .dynamic(@Sendable { _, _ in true })
+    let isSensitive: @Sendable (String, String) -> Bool = { _, _ in true }
+    let specifier: SecretsSpecifier<String, String> = .dynamic(isSensitive)
     #expect(specifier.description == "dynamic")
     #expect(specifier.debugDescription == "dynamic")
   }
@@ -94,5 +95,137 @@ struct CustomStringConvertibleTests {
     let decoder = ConfigBytesFromHexStringDecoder()
     #expect(decoder.description == "ConfigBytesFromHexStringDecoder")
     #expect(decoder.debugDescription == "ConfigBytesFromHexStringDecoder")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configValueDescription() {
+    let value = ConfigValue(.string("localhost"), isSecret: false)
+    #expect(value.description == "[string: localhost]")
+    #expect(value.debugDescription == "[string: localhost]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configValueSecretDescription() {
+    let secret = ConfigValue(.string("sk-abc123"), isSecret: true)
+    #expect(secret.description == "[string: <REDACTED>]")
+    #expect(secret.debugDescription == "[string: <REDACTED>]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func lookupResultFoundDescription() {
+    let value = ConfigValue(.string("localhost"), isSecret: false)
+    let result = LookupResult(encodedKey: "db.host", value: value)
+    #expect(result.description == "[key: db.host, [string: localhost]]")
+    #expect(result.debugDescription == "[key: db.host, [string: localhost]]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func lookupResultNotFoundDescription() {
+    let result = LookupResult(encodedKey: "db.host", value: nil)
+    #expect(result.description == "[key: db.host, (not found)]")
+    #expect(result.debugDescription == "[key: db.host, (not found)]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func accessEventMetadataDescription() {
+    let key = AbsoluteConfigKey(["db", "host"])
+    let loc = AccessEvent.Metadata.SourceLocation(fileID: "MyModule/Config.swift", line: 99)
+    let metadata = AccessEvent.Metadata(
+      accessKind: .get,
+      key: key,
+      valueType: .string,
+      sourceLocation: loc,
+      accessTimestamp: Date()
+    )
+    // description omits source location; debugDescription includes it
+    #expect(metadata.description == "get db.host as string")
+    #expect(metadata.debugDescription == "get db.host as string @ MyModule/Config.swift:99")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func accessEventProviderResultDescription() {
+    let value = ConfigValue(.string("localhost"), isSecret: false)
+    let lookup = LookupResult(encodedKey: "db.host", value: value)
+    let providerResult = AccessEvent.ProviderResult(
+      providerName: "InMemoryProvider",
+      result: .success(lookup)
+    )
+    #expect(providerResult.description == "InMemoryProvider: [key: db.host, [string: localhost]]")
+    #expect(providerResult.debugDescription == "InMemoryProvider: [key: db.host, [string: localhost]]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func accessEventProviderResultSecretDescription() {
+    let secret = ConfigValue(.string("sk-abc123"), isSecret: true)
+    let lookup = LookupResult(encodedKey: "api.key", value: secret)
+    let providerResult = AccessEvent.ProviderResult(
+      providerName: "InMemoryProvider",
+      result: .success(lookup)
+    )
+    // secrets are redacted even inside provider results
+    #expect(providerResult.description == "InMemoryProvider: [key: api.key, [string: <REDACTED>]]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func accessEventDescription() {
+    let key = AbsoluteConfigKey(["db", "host"])
+    let loc = AccessEvent.Metadata.SourceLocation(fileID: "MyModule/Config.swift", line: 99)
+    let metadata = AccessEvent.Metadata(
+      accessKind: .get,
+      key: key,
+      valueType: .string,
+      sourceLocation: loc,
+      accessTimestamp: Date()
+    )
+    let value = ConfigValue(.string("localhost"), isSecret: false)
+    let lookup = LookupResult(encodedKey: "db.host", value: value)
+    let providerResult = AccessEvent.ProviderResult(
+      providerName: "InMemoryProvider[ 0 values]",
+      result: .success(lookup)
+    )
+    let event = AccessEvent(
+      metadata: metadata,
+      providerResults: [providerResult],
+      result: .success(value)
+    )
+    // description omits source location and provider details
+    #expect(event.description == "AccessEvent[get db.host as string, result: [string: localhost]]")
+    // debugDescription includes source location and per-provider breakdown
+    #expect(
+      event.debugDescription
+        == "AccessEvent[get db.host as string @ MyModule/Config.swift:99, providers: [InMemoryProvider[ 0 values]: [key: db.host, [string: localhost]]], result: [string: localhost]]"
+    )
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configReaderDescription() {
+    let reader = ConfigReader(provider: InMemoryProvider(values: [:]))
+    #expect(reader.description == "ConfigReader[InMemoryProvider[ 0 values]]")
+    #expect(reader.debugDescription == "ConfigReader[InMemoryProvider[ 0 values]]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configReaderScopedDescription() {
+    let reader = ConfigReader(provider: InMemoryProvider(values: [:])).scoped(to: "http")
+    #expect(reader.description == "ConfigReader[prefix: http, InMemoryProvider[ 0 values]]")
+    #expect(reader.debugDescription == "ConfigReader[prefix: http, InMemoryProvider[ 0 values]]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func configSnapshotReaderDescription() {
+    let reader = ConfigReader(provider: InMemoryProvider(name: "test", values: [:]))
+    let snapshotReader = reader.snapshot()
+    #expect(snapshotReader.description == "ConfigSnapshotReader[of: InMemoryProvider[test]]")
+    #expect(snapshotReader.debugDescription == "ConfigSnapshotReader[of: InMemoryProvider[test]]")
+  }
+
+  @available(Configuration 1.0, *)
+  @Test func broadcastingAccessReporterDescription() {
+    struct NoOpReporter: AccessReporter {
+      func report(_ event: AccessEvent) {}
+    }
+    let reporter = BroadcastingAccessReporter(upstreams: [NoOpReporter(), NoOpReporter()])
+    #expect(reporter.description == "BroadcastingAccessReporter[2 reporters]")
+    #expect(reporter.debugDescription == "BroadcastingAccessReporter[2 reporters]")
   }
 }


### PR DESCRIPTION
### Motivation

I was using the library and noticed that printing a `ConfigKey` or an `AccessEvent` gives you something like `Configuration.ConfigKey` - the default Swift type description - which makes debugging harder than it needs to be. Issue #24 asks for exactly this, so I took a pass over all the public types.

### Modifications

Added `CustomStringConvertible` and `CustomDebugStringConvertible` conformances to all public API types:

- `ConfigKey` / `AbsoluteConfigKey` - dot-joined key path, e.g. `http.timeout`
- - `ConfigContextValue` - tagged value like `.int(8080)` or `.bool(true)` in debug
- - `LookupResult` / `ConfigValue` - key plus value or `(not found)`
- - `SecretsSpecifier` - `all`, `none`, `specific(N keys)`, or `dynamic`
- - `ConfigReader` / `ConfigSnapshotReader` - includes provider name and key prefix if set
- - `ConfigUpdatesAsyncSequence` - just the type name
- - `ConfigBytesFromBase64StringDecoder` / `ConfigBytesFromHexStringDecoder` - type name
- - `AccessEvent.Metadata.SourceLocation` - `fileID:line` (already had `CustomStringConvertible`; added `CustomDebugStringConvertible`)
- - `AccessEvent.Metadata` - `accessKind key as valueType`; debug adds source location
- - `AccessEvent.ProviderResult` - provider name plus lookup or error
- - `AccessEvent` - key metadata and result; debug includes per-provider breakdown
- - `BroadcastingAccessReporter` - reporter count
While wiring up `AccessReporter.swift` I also noticed a duplicate `CustomStringConvertible` extension for `SourceLocation` that had crept in (it also had a bug: it referenced `file` instead of `fileID`). Removed that.

### Result

All public types now print something meaningful. For example:

```
ConfigKey(["http", "timeout"]) -> "http.timeout"
SecretsSpecifier.specific(["apiKey", "token"]) -> "specific(2 keys)"
AccessEvent[...].debugDescription -> includes per-provider results
```

### Test Plan

Added `Tests/ConfigurationTests/CustomStringConvertibleTests.swift` with tests for all the new conformances using Swift Testing.

Resolves #24