### PR TITLE
Log missing configuration files when allowMissing is true

### DIFF
--- a/Sources/Configuration/Providers/EnvironmentVariables/EnvironmentVariablesProvider.swift
+++ b/Sources/Configuration/Providers/EnvironmentVariables/EnvironmentVariablesProvider.swift
@@ -18,6 +18,9 @@ import FoundationEssentials
 import Foundation
 #endif
 public import SystemPackage
+#if Logging
+import Logging
+#endif
 #if canImport(Darwin)
 import Darwin
 #elseif os(Windows)
@@ -299,6 +302,12 @@ public struct EnvironmentVariablesProvider: Sendable {
             data = loadedData
         } else if allowMissing {
             data = Data()
+            #if Logging
+            MissingConfigurationLogging.logMissingFile(
+                providerName: "EnvironmentVariablesProvider",
+                path: environmentFilePath
+            )
+            #endif
         } else {
             throw FileSystemError.fileNotFound(path: environmentFilePath)
         }

--- a/Sources/Configuration/Providers/Files/DirectoryFilesProvider.swift
+++ b/Sources/Configuration/Providers/Files/DirectoryFilesProvider.swift
@@ -18,6 +18,9 @@ public import FoundationEssentials
 public import Foundation
 #endif
 public import SystemPackage
+#if Logging
+import Logging
+#endif
 
 /// A configuration provider that reads values from individual files in a directory.
 ///
@@ -233,6 +236,12 @@ public struct DirectoryFilesProvider: Sendable {
             fileNames = loadedFileNames
         } else if allowMissing {
             fileNames = []
+            #if Logging
+            MissingConfigurationLogging.logMissingDirectory(
+                providerName: "DirectoryFilesProvider",
+                path: directoryPath
+            )
+            #endif
         } else {
             throw FileSystemError.directoryNotFound(path: directoryPath)
         }

--- a/Sources/Configuration/Providers/Files/FileProvider.swift
+++ b/Sources/Configuration/Providers/Files/FileProvider.swift
@@ -14,6 +14,10 @@
 
 public import SystemPackage
 
+#if Logging
+import Logging
+#endif
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -191,6 +195,12 @@ public struct FileProvider<Snapshot: FileConfigSnapshot>: Sendable {
                 parsingOptions: parsingOptions
             )
         } else if allowMissing {
+            #if Logging
+            MissingConfigurationLogging.logMissingFile(
+                providerName: providerName,
+                path: filePath
+            )
+            #endif
             self._snapshot = EmptyFileConfigSnapshot(providerName: providerName)
         } else {
             throw FileSystemError.fileNotFound(path: filePath)

--- a/Sources/Configuration/Providers/Files/ReloadingFileProvider.swift
+++ b/Sources/Configuration/Providers/Files/ReloadingFileProvider.swift
@@ -228,8 +228,12 @@ public final class ReloadingFileProvider<Snapshot: FileConfigSnapshot>: Sendable
             source = .missing
             dataSize = 0
 
-            logger.debug(
-                "Successfully initialized reloading file provider from a missing file"
+            logger.notice(
+                "Configuration file not found; treating as empty because allowMissing is true",
+                metadata: [
+                    "provider": .string(providerName),
+                    "path": .string(filePath.string),
+                ]
             )
         } else {
             throw FileSystemError.fileNotFound(path: filePath)

--- a/Sources/Configuration/Providers/MissingConfigurationLogging.swift
+++ b/Sources/Configuration/Providers/MissingConfigurationLogging.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if Logging
+
+import Logging
+import SystemPackage
+import Synchronization
+
+/// Helpers for logging when an optional configuration file or directory is missing.
+///
+/// These messages are only emitted when the `Logging` package trait is enabled,
+/// matching the dependency of ``AccessLogger`` and reloading providers.
+@available(Configuration 1.0, *)
+enum MissingConfigurationLogging {
+    /// Optional logger override used by unit tests.
+    private static let overrideLogger: Mutex<Logger?> = .init(nil)
+
+    /// Runs `body` while routing missing-config logs to `logger`.
+    /// - Parameters:
+    ///   - logger: The logger that should receive missing-config notices.
+    ///   - body: The work to perform while the override is active.
+    static func withOverrideLogger(
+        _ logger: Logger,
+        _ body: () async throws -> Void
+    ) async rethrows {
+        overrideLogger.withLock { $0 = logger }
+        defer { overrideLogger.withLock { $0 = nil } }
+        try await body()
+    }
+
+    /// Logs that a configuration file was missing and treated as empty.
+    /// - Parameters:
+    ///   - providerName: The configuration provider name for diagnostics.
+    ///   - path: The missing file path.
+    static func logMissingFile(
+        providerName: String,
+        path: FilePath
+    ) {
+        let resolved =
+            overrideLogger.withLock { $0 }
+            ?? Logger(label: "Configuration.\(providerName)")
+        resolved.notice(
+            "Configuration file not found; treating as empty because allowMissing is true",
+            metadata: [
+                "provider": .string(providerName),
+                "path": .string(path.string),
+            ]
+        )
+    }
+
+    /// Logs that a configuration directory was missing and treated as empty.
+    /// - Parameters:
+    ///   - providerName: The configuration provider name for diagnostics.
+    ///   - path: The missing directory path.
+    static func logMissingDirectory(
+        providerName: String,
+        path: FilePath
+    ) {
+        let resolved =
+            overrideLogger.withLock { $0 }
+            ?? Logger(label: "Configuration.\(providerName)")
+        resolved.notice(
+            "Configuration directory not found; treating as empty because allowMissing is true",
+            metadata: [
+                "provider": .string(providerName),
+                "path": .string(path.string),
+            ]
+        )
+    }
+}
+
+#endif

--- a/Tests/ConfigurationTests/MissingConfigurationLoggingTests.swift
+++ b/Tests/ConfigurationTests/MissingConfigurationLoggingTests.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if Logging
+
+import Testing
+@testable import Configuration
+import Logging
+import SystemPackage
+import ConfigurationTestingInternal
+
+@Suite(.serialized)
+struct MissingConfigurationLoggingTests {
+    @available(Configuration 1.0, *)
+    @Test func fileProviderLogsWhenAllowMissing() async throws {
+        // CollectingLogHandler keeps messages when handler.logLevel >= message.level,
+        // while Logger emits when logger.logLevel <= message.level. Both share this
+        // value, so .notice is required for notice-level diagnostics to be recorded.
+        var collectingLogHandler = CollectingLogHandler()
+        collectingLogHandler.logLevel = .notice
+        let logger = Logger(label: "Test", factory: { _ in collectingLogHandler })
+        try await MissingConfigurationLogging.withOverrideLogger(logger) {
+            let fileSystem = InMemoryFileSystem(files: [:])
+            _ = try await FileProvider<TestSnapshot>(
+                parsingOptions: .default,
+                filePath: "/etc/config.txt",
+                allowMissing: true,
+                fileSystem: fileSystem
+            )
+        }
+
+        let entries = collectingLogHandler.currentEntries
+        #expect(entries.count == 1)
+        #expect(entries[0].level == .notice)
+        #expect(entries[0].message.contains("allowMissing"))
+        #expect(entries[0].metadata["path"] == "/etc/config.txt")
+        #expect(entries[0].metadata["provider"] == "FileProvider<TestSnapshot>")
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func environmentFileLogsWhenAllowMissing() async throws {
+        var collectingLogHandler = CollectingLogHandler()
+        collectingLogHandler.logLevel = .notice
+        let logger = Logger(label: "Test", factory: { _ in collectingLogHandler })
+        try await MissingConfigurationLogging.withOverrideLogger(logger) {
+            let fileSystem = InMemoryFileSystem(files: [:])
+            _ = try await EnvironmentVariablesProvider(
+                environmentFilePath: "/missing/.env",
+                allowMissing: true,
+                fileSystem: fileSystem
+            )
+        }
+
+        let entries = collectingLogHandler.currentEntries
+        #expect(entries.count == 1)
+        #expect(entries[0].level == .notice)
+        #expect(entries[0].metadata["path"] == "/missing/.env")
+        #expect(entries[0].metadata["provider"] == "EnvironmentVariablesProvider")
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func directoryProviderLogsWhenAllowMissing() async throws {
+        var collectingLogHandler = CollectingLogHandler()
+        collectingLogHandler.logLevel = .notice
+        let logger = Logger(label: "Test", factory: { _ in collectingLogHandler })
+        try await MissingConfigurationLogging.withOverrideLogger(logger) {
+            let fileSystem = InMemoryFileSystem(files: [:])
+            _ = try await DirectoryFilesProvider(
+                directoryPath: "/missing/secrets",
+                allowMissing: true,
+                fileSystem: fileSystem
+            )
+        }
+
+        let entries = collectingLogHandler.currentEntries
+        #expect(entries.count == 1)
+        #expect(entries[0].level == .notice)
+        #expect(entries[0].metadata["path"] == "/missing/secrets")
+        #expect(entries[0].metadata["provider"] == "DirectoryFilesProvider")
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- When `allowMissing` is true and a configuration file/directory is missing, emit a `notice`-level log so the silent empty-config case is detectable (fixes #76).
- Logging is compiled only under the existing `Logging` package trait, so default dependencies are unchanged (per maintainer guidance).
- Updates `FileProvider`, `EnvironmentVariablesProvider`, `DirectoryFilesProvider`, and `ReloadingFileProvider`, with unit tests for the new diagnostics.

## Test plan
- [x] `ENABLE_ALL_TRAITS=1 swift test --filter MissingConfigurationLoggingTests`
- [x] Related provider suites (`FileProviderTests`, `EnvironmentVariablesProviderTests`, `DirectoryFilesProviderTests`, `ReloadingFileProviderTests`)
- [ ] CI on this PR