### PR TITLE
Add WebAssembly CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,16 @@ jobs:
       android_ndk_versions: '["r27d", "r29"]'
       linux_env_vars: 'ENABLE_ALL_TRAITS=1'
 
+  wasm-sdk:
+    name: WebAssembly Swift SDK
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
+    with:
+      enable_wasm_sdk_build: true
+      enable_linux_checks: false
+      enable_windows_checks: false
+      swift_flags: --target Configuration
+      swift_nightly_flags: --target Configuration
+
   macos-tests:
     name: macOS tests
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,6 +59,16 @@ jobs:
       android_ndk_versions: '["r27d", "r29"]'
       linux_env_vars: 'ENABLE_ALL_TRAITS=1'
 
+  wasm-sdk:
+    name: WebAssembly Swift SDK
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
+    with:
+      enable_wasm_sdk_build: true
+      enable_linux_checks: false
+      enable_windows_checks: false
+      swift_flags: --target Configuration
+      swift_nightly_flags: --target Configuration
+
   macos-tests:
     name: macOS tests
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main


### PR DESCRIPTION
## Summary

- add WebAssembly Swift SDK builds to pull request CI
- run the same WebAssembly coverage on `main` and scheduled builds
- scope the build to the `Configuration` target so host-only support targets are not included

Fixes #36.

## Testing

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.safe_load(File.read(f), aliases: true) }'`
- `git diff --check`
- `swift build --target Configuration` (Swift 6.2.1, macOS arm64)

I could not run the WebAssembly build locally because no WebAssembly Swift SDK is installed. The added CI job uses the repository's existing pinned `swiftlang/github-workflows` reusable workflow to install the SDK and build the target.
