### PR TITLE
Test package trait combinations in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,3 +143,39 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: false
       linux_6_1_enabled: false
+
+  trait-matrix:
+    name: Trait matrix (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    container: swift:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: No traits
+            flags: --disable-default-traits
+          - name: Default traits
+            flags: ""
+          - name: Logging
+            flags: --disable-default-traits --traits Logging
+          - name: JSON
+            flags: --disable-default-traits --traits JSON
+          - name: Reloading
+            flags: --disable-default-traits --traits Reloading
+          - name: CommandLineArguments
+            flags: --disable-default-traits --traits CommandLineArguments
+          - name: YAML
+            flags: --disable-default-traits --traits YAML
+          - name: PropertyList
+            flags: --disable-default-traits --traits PropertyList
+          - name: All traits
+            flags: --enable-all-traits
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Mark repository as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Test
+        run: env -u ENABLE_ALL_TRAITS swift test --explicit-target-dependency-import-check error ${{ matrix.flags }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -150,3 +150,39 @@ jobs:
       linux_5_10_enabled: false
       linux_6_0_enabled: false
       linux_6_1_enabled: false
+
+  trait-matrix:
+    name: Trait matrix (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    container: swift:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: No traits
+            flags: --disable-default-traits
+          - name: Default traits
+            flags: ""
+          - name: Logging
+            flags: --disable-default-traits --traits Logging
+          - name: JSON
+            flags: --disable-default-traits --traits JSON
+          - name: Reloading
+            flags: --disable-default-traits --traits Reloading
+          - name: CommandLineArguments
+            flags: --disable-default-traits --traits CommandLineArguments
+          - name: YAML
+            flags: --disable-default-traits --traits YAML
+          - name: PropertyList
+            flags: --disable-default-traits --traits PropertyList
+          - name: All traits
+            flags: --enable-all-traits
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Mark repository as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Test
+        run: env -u ENABLE_ALL_TRAITS swift test --explicit-target-dependency-import-check error ${{ matrix.flags }}


### PR DESCRIPTION
### Motivation

The existing CI enables every package trait together. That can miss conditional-compilation problems that only appear with default traits disabled or with one trait enabled independently.

Resolves #29.

### Modifications

- Add a latest-Swift trait matrix to the pull request and main workflows.
- Test no traits, the default trait set, every individual declared trait, and all traits.
- Clear the workflow-level `ENABLE_ALL_TRAITS` variable before each matrix command so the default and individual rows exercise their intended configuration.

### Result

Changes to trait-gated code will now be checked against each supported package configuration instead of only the all-traits build.

### Test Plan

- `actionlint .github/workflows/main.yml .github/workflows/pull_request.yml`
- `git diff --check`
- Ran `swift test` locally with Swift 6.2.1 for all nine matrix configurations: no traits, defaults, Logging, JSON, Reloading, CommandLineArguments, YAML, PropertyList, and all traits.

The GitHub-hosted `swift:latest` matrix is expected to provide the Linux/latest-Swift validation for this workflow change.
