### PR TITLE
Update Swift 6.2 benchmark thresholds

### DIFF
--- a/Benchmarks/Thresholds/6.2/Benchmarks.ConfigReader_InMemoryProvider_found_int.p90.json
+++ b/Benchmarks/Thresholds/6.2/Benchmarks.ConfigReader_InMemoryProvider_found_int.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 3008
+  "mallocCountTotal" : 3009
 }

--- a/Benchmarks/Thresholds/6.2/Benchmarks.ConfigReader_InMemoryProvider_found_string.p90.json
+++ b/Benchmarks/Thresholds/6.2/Benchmarks.ConfigReader_InMemoryProvider_found_string.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 3008
+  "mallocCountTotal" : 3009
 }

--- a/Benchmarks/Thresholds/6.2/Benchmarks.EnvironmentVariablesProvider_notFound_string.p90.json
+++ b/Benchmarks/Thresholds/6.2/Benchmarks.EnvironmentVariablesProvider_notFound_string.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 3002
+  "mallocCountTotal" : 3003
 }


### PR DESCRIPTION
### Motivation

The Linux 6.2 benchmarks have been failing since package-benchmark 1.35.0, which replaced jemalloc with a custom malloc interposer and shifted the reported allocation counts.

### Modifications

Bump the three affected thresholds. 6.3 and the nightlies are unaffected.

### Result

Benchmarks pass again.

### Test Plan

Ran `swift package benchmark thresholds check` against 6.2 in a `swift:6.2-noble` container. Also confirmed the counts are unchanged when pinning package-benchmark to 1.34.1.