### PR TITLE
Log optional missing configuration sources

### DIFF
--- a/Sources/Configuration/Documentation.docc/Guides/Example-use-cases.md
+++ b/Sources/Configuration/Documentation.docc/Guides/Example-use-cases.md
@@ -112,6 +112,8 @@ let config = ConfigReader(
 let port = config.int(forKey: "server.port", default: 8080)
 ```
 
+When the `Logging` trait is enabled, stateless file-based providers also emit a warning with the missing path. This keeps optional files from failing startup while still making a likely deployment mistake visible.
+
 The same applies to other file-based providers:
 
 ```swift

--- a/Sources/Configuration/Providers/EnvironmentVariables/EnvironmentVariablesProvider.swift
+++ b/Sources/Configuration/Providers/EnvironmentVariables/EnvironmentVariablesProvider.swift
@@ -284,6 +284,7 @@ public struct EnvironmentVariablesProvider: Sendable {
     ///   - secretsSpecifier: Specifies which environment variables should be treated as secrets.
     ///   - bytesDecoder: The decoder used for converting string values to byte arrays.
     ///   - arraySeparator: The character used to separate elements in array values.
+    ///   - missingFileLogger: The logger used when an allowed environment file is missing.
     /// - Throws: If the file is malformed, or if missing when allowMissing is `false`.
     internal init(
         environmentFilePath: FilePath,
@@ -291,13 +292,19 @@ public struct EnvironmentVariablesProvider: Sendable {
         fileSystem: some CommonProviderFileSystem,
         secretsSpecifier: SecretsSpecifier<String, String> = .none,
         bytesDecoder: some ConfigBytesFromStringDecoder = .base64,
-        arraySeparator: Character = ","
+        arraySeparator: Character = ",",
+        missingFileLogger: MissingFileLogger = .init(label: "EnvironmentVariablesProvider")
     ) async throws {
         let loadedData = try await fileSystem.fileContents(atPath: environmentFilePath)
         let data: Data
         if let loadedData {
             data = loadedData
         } else if allowMissing {
+            missingFileLogger.warning(
+                "Environment file is missing; using empty configuration",
+                pathKey: "filePath",
+                path: environmentFilePath.string
+            )
             data = Data()
         } else {
             throw FileSystemError.fileNotFound(path: environmentFilePath)

--- a/Sources/Configuration/Providers/Files/DirectoryFilesProvider.swift
+++ b/Sources/Configuration/Providers/Files/DirectoryFilesProvider.swift
@@ -186,19 +186,22 @@ public struct DirectoryFilesProvider: Sendable {
     ///   - fileSystem: The file system implementation to use.
     ///   - secretsSpecifier: Specifies which values should be treated as secrets. Defaults to `.all`.
     ///   - arraySeparator: The character used to separate elements in array values. Defaults to comma.
+    ///   - missingFileLogger: The logger used when an allowed configuration directory is missing.
     /// - Throws: If the directory doesn't exist or is unreadable.
     internal init(
         directoryPath: FilePath,
         allowMissing: Bool,
         fileSystem: some CommonProviderFileSystem,
         secretsSpecifier: SecretsSpecifier<String, Data> = .all,
-        arraySeparator: Character = ","
+        arraySeparator: Character = ",",
+        missingFileLogger: MissingFileLogger = .init(label: "DirectoryFilesProvider")
     ) async throws {
         let fileValues = try await Self.loadDirectory(
             at: directoryPath,
             allowMissing: allowMissing,
             fileSystem: fileSystem,
-            secretsSpecifier: secretsSpecifier
+            secretsSpecifier: secretsSpecifier,
+            missingFileLogger: missingFileLogger
         )
         self._snapshot = .init(
             fileValues: fileValues,
@@ -219,19 +222,26 @@ public struct DirectoryFilesProvider: Sendable {
     ///     - When `true`, if the directory is missing, treats it as empty.
     ///   - fileSystem: The file system implementation to use.
     ///   - secretsSpecifier: Specifies which values should be treated as secrets.
+    ///   - missingFileLogger: The logger used when an allowed configuration directory is missing.
     /// - Returns: A dictionary of file values keyed by file name.
     /// - Throws: If the directory doesn't exist or is unreadable, or any file is unreadable.
     private static func loadDirectory(
         at directoryPath: FilePath,
         allowMissing: Bool,
         fileSystem: some CommonProviderFileSystem,
-        secretsSpecifier: SecretsSpecifier<String, Data>
+        secretsSpecifier: SecretsSpecifier<String, Data>,
+        missingFileLogger: MissingFileLogger
     ) async throws -> [String: FileValue] {
         let loadedFileNames = try await fileSystem.listFileNames(atPath: directoryPath)
         let fileNames: [String]
         if let loadedFileNames {
             fileNames = loadedFileNames
         } else if allowMissing {
+            missingFileLogger.warning(
+                "Configuration directory is missing; using empty configuration",
+                pathKey: "directoryPath",
+                path: directoryPath.string
+            )
             fileNames = []
         } else {
             throw FileSystemError.directoryNotFound(path: directoryPath)

--- a/Sources/Configuration/Providers/Files/FileProvider.swift
+++ b/Sources/Configuration/Providers/Files/FileProvider.swift
@@ -172,13 +172,15 @@ public struct FileProvider<Snapshot: FileConfigSnapshot>: Sendable {
     ///     - When `false` (the default), if the file is missing or malformed, throws an error.
     ///     - When `true`, if the file is missing, treats it as empty. Malformed files still throw an error.
     ///   - fileSystem: The file system implementation to use for reading the file.
+    ///   - missingFileLogger: The logger used when an allowed configuration file is missing.
     /// - Throws: If the file cannot be read or if snapshot creation fails.
     internal init(
         snapshotType: Snapshot.Type = Snapshot.self,
         parsingOptions: Snapshot.ParsingOptions,
         filePath: FilePath,
         allowMissing: Bool,
-        fileSystem: some CommonProviderFileSystem
+        fileSystem: some CommonProviderFileSystem,
+        missingFileLogger: MissingFileLogger = .init(label: "FileProvider")
     ) async throws {
         let fileContents = try await fileSystem.fileContents(atPath: filePath)
         let providerName = "FileProvider<\(Snapshot.self)>"
@@ -191,6 +193,11 @@ public struct FileProvider<Snapshot: FileConfigSnapshot>: Sendable {
                 parsingOptions: parsingOptions
             )
         } else if allowMissing {
+            missingFileLogger.warning(
+                "Configuration file is missing; using empty configuration",
+                pathKey: "filePath",
+                path: filePath.string
+            )
             self._snapshot = EmptyFileConfigSnapshot(providerName: providerName)
         } else {
             throw FileSystemError.fileNotFound(path: filePath)

--- a/Sources/Configuration/Providers/MissingFileLogger.swift
+++ b/Sources/Configuration/Providers/MissingFileLogger.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if Logging
+import Logging
+#endif
+
+/// Logs optional missing configuration sources when logging support is enabled.
+@available(Configuration 1.0, *)
+internal struct MissingFileLogger: Sendable {
+    #if Logging
+    /// The underlying SwiftLog logger.
+    private let logger: Logger
+
+    /// Creates a logger with the specified label.
+    init(label: String) {
+        self.logger = Logger(label: label)
+    }
+
+    /// Creates a logger backed by an existing SwiftLog logger.
+    init(logger: Logger) {
+        self.logger = logger
+    }
+    #else
+    /// Creates a no-op logger when logging support is disabled.
+    init(label: String) {}
+    #endif
+
+    /// Records that an optional configuration source was missing.
+    func warning(_ message: String, pathKey: String, path: String) {
+        #if Logging
+        logger.warning(
+            .init(stringLiteral: message),
+            metadata: [pathKey: .string(path)]
+        )
+        #endif
+    }
+}

--- a/Sources/ConfigurationTestingInternal/CollectingLogHandler.swift
+++ b/Sources/ConfigurationTestingInternal/CollectingLogHandler.swift
@@ -108,7 +108,7 @@ package struct CollectingLogHandler: LogHandler {
         function: String,
         line: UInt
     ) {
-        guard self.logLevel >= level else {
+        guard level >= self.logLevel else {
             return
         }
         self.storage.append(level: level, message: message, metadata: self.metadata.merging(metadata ?? [:]) { $1 })

--- a/Tests/ConfigurationTests/DirectoryFilesProviderTests.swift
+++ b/Tests/ConfigurationTests/DirectoryFilesProviderTests.swift
@@ -18,6 +18,9 @@ import Foundation
 import ConfigurationTestingInternal
 import ConfigurationTesting
 import SystemPackage
+#if Logging
+import Logging
+#endif
 
 struct DirectoryFilesProviderTests {
 
@@ -126,10 +129,29 @@ struct DirectoryFilesProviderTests {
     @available(Configuration 1.0, *)
     @Test func missingDirectoryAllowedMissing() async throws {
         let fileSystem = InMemoryFileSystem(files: [:])
+        #if Logging
+        let logHandler = CollectingLogHandler()
+        let logger = Logger(label: "Test", factory: { _ in logHandler })
+        let missingFileLogger = MissingFileLogger(logger: logger)
+        #else
+        let missingFileLogger = MissingFileLogger(label: "Test")
+        #endif
         _ = try await DirectoryFilesProvider(
             directoryPath: "/test",
             allowMissing: true,
-            fileSystem: fileSystem
+            fileSystem: fileSystem,
+            missingFileLogger: missingFileLogger
         )
+        #if Logging
+        #expect(
+            logHandler.currentEntries == [
+                Entry(
+                    level: .warning,
+                    message: "Configuration directory is missing; using empty configuration",
+                    metadata: ["directoryPath": "/test"]
+                )
+            ]
+        )
+        #endif
     }
 }

--- a/Tests/ConfigurationTests/EnvironmentVariablesProviderTests.swift
+++ b/Tests/ConfigurationTests/EnvironmentVariablesProviderTests.swift
@@ -18,6 +18,9 @@ import Foundation
 import ConfigurationTestingInternal
 import ConfigurationTesting
 import SystemPackage
+#if Logging
+import Logging
+#endif
 
 struct EnvironmentVariablesProviderTests {
 
@@ -270,11 +273,30 @@ struct EnvironmentVariablesProviderTests {
     @Test func loadEnvironmentAllowedMissing() async throws {
         let fileSystem = InMemoryFileSystem(files: [:])
         let envFilePath: FilePath = "/tmp/definitelyNotAnEnvFile"
+        #if Logging
+        let logHandler = CollectingLogHandler()
+        let logger = Logger(label: "Test", factory: { _ in logHandler })
+        let missingFileLogger = MissingFileLogger(logger: logger)
+        #else
+        let missingFileLogger = MissingFileLogger(label: "Test")
+        #endif
         _ = try await EnvironmentVariablesProvider(
             environmentFilePath: envFilePath,
             allowMissing: true,
-            fileSystem: fileSystem
+            fileSystem: fileSystem,
+            missingFileLogger: missingFileLogger
         )
+        #if Logging
+        #expect(
+            logHandler.currentEntries == [
+                Entry(
+                    level: .warning,
+                    message: "Environment file is missing; using empty configuration",
+                    metadata: ["filePath": "/tmp/definitelyNotAnEnvFile"]
+                )
+            ]
+        )
+        #endif
     }
 }
 

--- a/Tests/ConfigurationTests/FileProviderTests.swift
+++ b/Tests/ConfigurationTests/FileProviderTests.swift
@@ -73,12 +73,31 @@ struct FileProviderTests {
     @available(Configuration 1.0, *)
     @Test func missingFileAllowMissing() async throws {
         let fileSystem = InMemoryFileSystem(files: [:])
+        #if Logging
+        let logHandler = CollectingLogHandler()
+        let logger = Logger(label: "Test", factory: { _ in logHandler })
+        let missingFileLogger = MissingFileLogger(logger: logger)
+        #else
+        let missingFileLogger = MissingFileLogger(label: "Test")
+        #endif
         _ = try await FileProvider<TestSnapshot>(
             parsingOptions: .default,
             filePath: "/etc/config.txt",
             allowMissing: true,
-            fileSystem: fileSystem
+            fileSystem: fileSystem,
+            missingFileLogger: missingFileLogger
         )
+        #if Logging
+        #expect(
+            logHandler.currentEntries == [
+                Entry(
+                    level: .warning,
+                    message: "Configuration file is missing; using empty configuration",
+                    metadata: ["filePath": "/etc/config.txt"]
+                )
+            ]
+        )
+        #endif
     }
 
     @available(Configuration 1.0, *)


### PR DESCRIPTION
## Summary

- emit a warning when `FileProvider`, `DirectoryFilesProvider`, or file-backed `EnvironmentVariablesProvider` accepts a missing source
- compile the logging path only with the `Logging` trait, keeping the existing no-logging build dependency-free
- include the missing path as structured metadata and document the behavior
- cover all three providers with collecting-logger assertions

Closes #76.

## Testing

- `swift test --enable-all-traits` — 136 tests passed
- `swift test` — 109 tests passed
- `swift test --disable-default-traits` — 106 tests passed
- `swift format lint --strict` on all changed Swift files — passed
- `git diff --check` — passed

The all-traits build still prints the existing swift-log deprecation warning for `CollectingLogHandler`'s legacy protocol method; it does not fail the build or tests.
