### PR TITLE
Support fixed-width integer raw enums

### DIFF
--- a/Scripts/gyb_utils.py
+++ b/Scripts/gyb_utils.py
@@ -53,12 +53,32 @@ string_convertible_types = [
 int_convertible_types = [
     {
         "protocol": "ExpressibleByConfigInt",
+        "whereClause": "",
+        "wrap": "uncast($0)",
         "testType": "TestIntConvertible",
         "testSuffix": "IntConvertible"
     },
     {
-        "protocol": "RawRepresentable<Int>",
+        "protocol": "RawRepresentable",
+        "whereClause": " where Value.RawValue: FixedWidthInteger",
+        "wrap": "try uncast($0, key: key)",
         "testType": "TestIntEnum",
         "testSuffix": "IntEnum"
+    },
+]
+
+int_convertible_test_types = [
+    {
+        "testType": "TestIntConvertible",
+        "testSuffix": "IntConvertible"
+    },
+    {
+        "testType": "TestIntEnum",
+        "testSuffix": "IntEnum"
+    },
+    {
+        "testType": "TestUInt8Enum",
+        "testSuffix": "UInt8Enum",
+        "lowerTestSuffix": "uint8Enum"
     },
 ]

--- a/Sources/Configuration/ConfigReader+internalHelpers.swift
+++ b/Sources/Configuration/ConfigReader+internalHelpers.swift
@@ -100,6 +100,31 @@ private func mergingIsSecret(
     )
 }
 
+/// Wraps an optional converted value for access reporting.
+///
+/// Wrapping is allowed to fail because a converted value can have a representation
+/// that `ConfigContent` can't store, such as a `UInt64` raw value above `Int.max`.
+@available(Configuration 1.0, *)
+private func accessResult<Value>(
+    _ value: (Value, Bool)?,
+    wrap: (Value) throws -> ConfigContent
+) -> Result<ConfigValue?, any Error> {
+    Result {
+        try value.map { ConfigValue(try wrap($0.0), isSecret: $0.1) }
+    }
+}
+
+/// Wraps a converted value for access reporting.
+@available(Configuration 1.0, *)
+private func accessResult<Value>(
+    _ value: (Value, Bool),
+    wrap: (Value) throws -> ConfigContent
+) -> Result<ConfigValue?, any Error> {
+    Result {
+        ConfigValue(try wrap(value.0), isSecret: value.1)
+    }
+}
+
 /// Retrieves a configuration value from a provider with full access tracking.
 ///
 /// This is the core implementation function that handles configuration value retrieval,
@@ -136,7 +161,7 @@ internal func valueFromReader<Value>(
     valueClosure: (AbsoluteConfigKey, ConfigType) -> ([AccessEvent.ProviderResult], Result<ConfigValue?, any Error>),
     accessReporter: (any AccessReporter)?,
     unwrap: (ConfigContent) throws -> Value,
-    wrap: (Value) -> ConfigContent,
+    wrap: (Value) throws -> ConfigContent,
     fileID: String,
     line: UInt
 ) -> Value? {
@@ -177,7 +202,7 @@ internal func valueFromReader<Value>(
                 ),
                 providerResults: providerResults,
                 conversionError: conversionError,
-                result: .success(finalValue.flatMap { ConfigValue(wrap($0.0), isSecret: $0.1) })
+                result: accessResult(finalValue, wrap: wrap)
             )
         )
     }
@@ -210,7 +235,7 @@ internal func valueFromReader<Value>(
     valueClosure: (AbsoluteConfigKey, ConfigType) -> ([AccessEvent.ProviderResult], Result<ConfigValue?, any Error>),
     accessReporter: (any AccessReporter)?,
     unwrap: (ConfigContent) throws -> Value,
-    wrap: (Value) -> ConfigContent,
+    wrap: (Value) throws -> ConfigContent,
     fileID: String,
     line: UInt
 ) -> Value {
@@ -253,7 +278,7 @@ internal func valueFromReader<Value>(
                 ),
                 providerResults: providerResults,
                 conversionError: conversionError,
-                result: .success(ConfigValue(wrap(finalValue.0), isSecret: finalValue.1))
+                result: accessResult(finalValue, wrap: wrap)
             )
         )
     }
@@ -286,7 +311,7 @@ internal func requiredValueFromReader<Value>(
     valueClosure: (AbsoluteConfigKey, ConfigType) -> ([AccessEvent.ProviderResult], Result<ConfigValue?, any Error>),
     accessReporter: (any AccessReporter)?,
     unwrap: (ConfigContent) throws -> Value,
-    wrap: (Value) -> ConfigContent,
+    wrap: (Value) throws -> ConfigContent,
     fileID: String,
     line: UInt
 ) throws -> Value {
@@ -326,7 +351,7 @@ internal func requiredValueFromReader<Value>(
                 ),
                 providerResults: providerResults,
                 conversionError: conversionError,
-                result: finalResult.map { ConfigValue(wrap($0.0), isSecret: $0.1) }
+                result: finalResult.flatMap { accessResult($0, wrap: wrap) }
             )
         )
     }
@@ -352,7 +377,7 @@ extension ConfigReader {
         type: ConfigType,
         isSecret: Bool,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) -> Value? {
@@ -388,7 +413,7 @@ extension ConfigReader {
         isSecret: Bool,
         default defaultValue: Value,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) -> Value {
@@ -424,7 +449,7 @@ extension ConfigReader {
         type: ConfigType,
         isSecret: Bool,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) throws -> Value {
@@ -459,7 +484,7 @@ extension ConfigReader {
         type: ConfigType,
         isSecret: Bool,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) async throws -> Value? {
@@ -495,11 +520,7 @@ extension ConfigReader {
                     ),
                     providerResults: providerResults,
                     conversionError: conversionError,
-                    result: finalResult.map { success in
-                        success.flatMap {
-                            ConfigValue(wrap($0.0), isSecret: $0.1)
-                        }
-                    }
+                    result: finalResult.flatMap { accessResult($0, wrap: wrap) }
                 )
             )
         }
@@ -525,7 +546,7 @@ extension ConfigReader {
         isSecret: Bool,
         default defaultValue: Value,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) async throws -> Value {
@@ -559,7 +580,7 @@ extension ConfigReader {
                     ),
                     providerResults: providerResults,
                     conversionError: conversionError,
-                    result: finalResult.map { ConfigValue(wrap($0.0), isSecret: $0.1) }
+                    result: finalResult.flatMap { accessResult($0, wrap: wrap) }
                 )
             )
         }
@@ -583,7 +604,7 @@ extension ConfigReader {
         type: ConfigType,
         isSecret: Bool,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) async throws -> Value {
@@ -617,7 +638,7 @@ extension ConfigReader {
                     ),
                     providerResults: providerResults,
                     conversionError: conversionError,
-                    result: finalResult.map { ConfigValue(wrap($0.0), isSecret: $0.1) }
+                    result: finalResult.flatMap { accessResult($0, wrap: wrap) }
                 )
             )
         }
@@ -642,7 +663,7 @@ extension ConfigReader {
         type: ConfigType,
         isSecret: Bool,
         unwrap: @Sendable @escaping (ConfigContent) throws -> Value,
-        wrap: @Sendable @escaping (Value) -> ConfigContent,
+        wrap: @Sendable @escaping (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt,
         updatesHandler: (ConfigUpdatesAsyncSequence<Value?, Never>) async throws -> Return
@@ -687,9 +708,7 @@ extension ConfigReader {
                                 ),
                                 providerResults: providerResults,
                                 conversionError: conversionError,
-                                result: .success(
-                                    finalValue.map { ConfigValue(wrap($0.0), isSecret: $0.1) }
-                                )
+                                result: accessResult(finalValue, wrap: wrap)
                             )
                         )
                     }
@@ -719,7 +738,7 @@ extension ConfigReader {
         isSecret: Bool,
         default defaultValue: Value,
         unwrap: @Sendable @escaping (ConfigContent) throws -> Value,
-        wrap: @Sendable @escaping (Value) -> ConfigContent,
+        wrap: @Sendable @escaping (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt,
         updatesHandler: (ConfigUpdatesAsyncSequence<Value, Never>) async throws -> Return
@@ -766,7 +785,7 @@ extension ConfigReader {
                                 ),
                                 providerResults: providerResults,
                                 conversionError: conversionError,
-                                result: .success(ConfigValue(wrap(finalValue.0), isSecret: finalValue.1))
+                                result: accessResult(finalValue, wrap: wrap)
                             )
                         )
                     }
@@ -795,7 +814,7 @@ extension ConfigReader {
         type: ConfigType,
         isSecret: Bool,
         unwrap: @Sendable @escaping (ConfigContent) throws -> Value,
-        wrap: @Sendable @escaping (Value) -> ConfigContent,
+        wrap: @Sendable @escaping (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt,
         updatesHandler: (ConfigUpdatesAsyncSequence<Value, any Error>) async throws -> Return
@@ -840,7 +859,7 @@ extension ConfigReader {
                                 ),
                                 providerResults: providerResults,
                                 conversionError: conversionError,
-                                result: finalResult.map { ConfigValue(wrap($0.0), isSecret: $0.1) }
+                                result: finalResult.flatMap { accessResult($0, wrap: wrap) }
                             )
                         )
                     }
@@ -947,7 +966,7 @@ extension ConfigReader {
         return typedValue
     }
 
-    /// Casts an integer into a raw representable type.
+    /// Casts an integer into a raw representable type with an integer raw value.
     ///
     /// - Parameters:
     ///   - int: The integer to cast.
@@ -955,12 +974,14 @@ extension ConfigReader {
     ///   - key: The config key for error context.
     /// - Throws: A `ConfigError` if conversion fails.
     /// - Returns: The typed value.
-    internal func cast<Value: RawRepresentable<Int>>(
+    internal func cast<Value: RawRepresentable>(
         _ int: Int,
         type: Value.Type,
         key: ConfigKey
-    ) throws -> Value {
-        guard let typedValue = Value(rawValue: int) else {
+    ) throws -> Value where Value.RawValue: FixedWidthInteger {
+        guard let rawValue = Value.RawValue(exactly: int),
+            let typedValue = Value(rawValue: rawValue)
+        else {
             throw ConfigError.configValueFailedToCast(name: keyPrefix.appending(key).description, type: "\(type)")
         }
         return typedValue
@@ -986,23 +1007,44 @@ extension ConfigReader {
         .intArray(values.map(\.configInt))
     }
 
-    /// Converts a raw representable type into raw config content.
+    /// Converts a raw representable type with an integer raw value into raw config content.
     ///
-    /// - Parameter value: The typed value with an int raw value.
+    /// - Parameters:
+    ///   - value: The typed value with an integer raw value.
+    ///   - key: The config key for error context.
     /// - Returns: The wrapped config content as an int.
-    internal func uncast<Value: RawRepresentable<Int>>(
-        _ value: Value
-    ) -> ConfigContent {
-        .int(value.rawValue)
+    /// - Throws: A `ConfigError` if the raw value can't be represented as an `Int`.
+    internal func uncast<Value: RawRepresentable>(
+        _ value: Value,
+        key: ConfigKey
+    ) throws -> ConfigContent where Value.RawValue: FixedWidthInteger {
+        guard let int = Int(exactly: value.rawValue) else {
+            throw ConfigError.configValueFailedToCast(name: keyPrefix.appending(key).description, type: "Int")
+        }
+        return .int(int)
     }
 
-    /// Converts an array of raw representable types into raw config content.
+    /// Converts an array of raw representable types with integer raw values into raw config content.
     ///
-    /// - Parameter values: The array of typed values with int raw values to convert.
+    /// - Parameters:
+    ///   - values: The array of typed values with integer raw values to convert.
+    ///   - key: The config key for error context.
     /// - Returns: The wrapped config content as an int array.
-    internal func uncast<Value: RawRepresentable<Int>>(
-        _ values: [Value]
-    ) -> ConfigContent {
-        .intArray(values.map(\.rawValue))
+    /// - Throws: A `ConfigError` if a raw value can't be represented as an `Int`.
+    internal func uncast<Value: RawRepresentable>(
+        _ values: [Value],
+        key: ConfigKey
+    ) throws -> ConfigContent where Value.RawValue: FixedWidthInteger {
+        .intArray(
+            try values.map { value in
+                guard let int = Int(exactly: value.rawValue) else {
+                    throw ConfigError.configValueFailedToCast(
+                        name: keyPrefix.appending(key).description,
+                        type: "Int"
+                    )
+                }
+                return int
+            }
+        )
     }
 }

--- a/Sources/Configuration/ConfigReader+methods.swift
+++ b/Sources/Configuration/ConfigReader+methods.swift
@@ -1695,19 +1695,19 @@ extension ConfigReader {
     ///   - fileID: The file ID where this call originates. Used for access reporting.
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The value converted to the expected type if found and convertible, otherwise `nil`.
-    public func int<Value: RawRepresentable<Int>>(
+    public func int<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> Value? {
+    ) -> Value? where Value.RawValue: FixedWidthInteger {
         value(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1731,21 +1731,21 @@ extension ConfigReader {
     ///   - fileID: The file ID where this call originates. Used for access reporting.
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config value if found and convertible, otherwise the default value.
-    public func int<Value: RawRepresentable<Int>>(
+    public func int<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         default defaultValue: Value,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> Value {
+    ) -> Value where Value.RawValue: FixedWidthInteger {
         value(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1768,19 +1768,19 @@ extension ConfigReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config value converted to the expected type.
     /// - Throws: An error if the value is missing or can't be converted to the expected type.
-    public func requiredInt<Value: RawRepresentable<Int>>(
+    public func requiredInt<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) throws -> Value {
+    ) throws -> Value where Value.RawValue: FixedWidthInteger {
         try requiredValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1802,19 +1802,19 @@ extension ConfigReader {
     ///   - fileID: The file ID where this call originates. Used for access reporting.
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: An array of values converted to the expected type if found and convertible, otherwise `nil`.
-    public func intArray<Value: RawRepresentable<Int>>(
+    public func intArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> [Value]? {
+    ) -> [Value]? where Value.RawValue: FixedWidthInteger {
         value(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1838,21 +1838,21 @@ extension ConfigReader {
     ///   - fileID: The file ID where this call originates. Used for access reporting.
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config array if found and convertible, otherwise the default array.
-    public func intArray<Value: RawRepresentable<Int>>(
+    public func intArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         default defaultValue: [Value],
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> [Value] {
+    ) -> [Value] where Value.RawValue: FixedWidthInteger {
         value(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1875,19 +1875,19 @@ extension ConfigReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config array converted to the expected type.
     /// - Throws: An error if the value is missing or can't be converted to the expected type.
-    public func requiredIntArray<Value: RawRepresentable<Int>>(
+    public func requiredIntArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) throws -> [Value] {
+    ) throws -> [Value] where Value.RawValue: FixedWidthInteger {
         try requiredValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -3610,19 +3610,19 @@ extension ConfigReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The value converted to the expected type if found and convertible, otherwise `nil`.
     /// - Throws: An error if the underlying provider throws or if the value can't be converted to the expected type.
-    public func fetchInt<Value: RawRepresentable<Int>>(
+    public func fetchInt<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> Value? {
+    ) async throws -> Value? where Value.RawValue: FixedWidthInteger {
         try await fetchValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -3646,21 +3646,21 @@ extension ConfigReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config value if found and convertible, otherwise the default value.
     /// - Throws: An error if the underlying provider throws or if the value can't be converted to the expected type.
-    public func fetchInt<Value: RawRepresentable<Int>>(
+    public func fetchInt<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         default defaultValue: Value,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> Value {
+    ) async throws -> Value where Value.RawValue: FixedWidthInteger {
         try await fetchValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -3683,19 +3683,19 @@ extension ConfigReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config value converted to the expected type.
     /// - Throws: An error if the underlying provider throws, the value is missing, or can't be converted to the expected type.
-    public func fetchRequiredInt<Value: RawRepresentable<Int>>(
+    public func fetchRequiredInt<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> Value {
+    ) async throws -> Value where Value.RawValue: FixedWidthInteger {
         try await fetchRequiredValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -3718,19 +3718,19 @@ extension ConfigReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: An array of values converted to the expected type if found and convertible, otherwise `nil`.
     /// - Throws: An error if the underlying provider throws or if the value can't be converted to the expected type.
-    public func fetchIntArray<Value: RawRepresentable<Int>>(
+    public func fetchIntArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> [Value]? {
+    ) async throws -> [Value]? where Value.RawValue: FixedWidthInteger {
         try await fetchValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -3754,21 +3754,21 @@ extension ConfigReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config array if found and convertible, otherwise the default array.
     /// - Throws: An error if the underlying provider throws or if the value can't be converted to the expected type.
-    public func fetchIntArray<Value: RawRepresentable<Int>>(
+    public func fetchIntArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         default defaultValue: [Value],
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> [Value] {
+    ) async throws -> [Value] where Value.RawValue: FixedWidthInteger {
         try await fetchValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -3791,19 +3791,19 @@ extension ConfigReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config array converted to the expected type.
     /// - Throws: An error if the underlying provider throws, the value is missing, or can't be converted to the expected type.
-    public func fetchRequiredIntArray<Value: RawRepresentable<Int>>(
+    public func fetchRequiredIntArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> [Value] {
+    ) async throws -> [Value] where Value.RawValue: FixedWidthInteger {
         try await fetchRequiredValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -6003,20 +6003,20 @@ extension ConfigReader {
     ///     produces `nil` if the value is missing or can't be converted.
     /// - Returns: The result produced by the handler.
     /// - Throws: Rethrows any error thrown by the handler or the underlying watch operation.
-    public func watchInt<Value: RawRepresentable<Int> & Sendable, Return: ~Copyable>(
+    public func watchInt<Value: RawRepresentable & Sendable, Return: ~Copyable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<Value?, Never>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return where Value.RawValue: FixedWidthInteger {
         try await watchValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -6048,7 +6048,7 @@ extension ConfigReader {
     ///     produces the default value if the provider returned a `nil` value or conversion failed.
     /// - Returns: The result produced by the handler.
     /// - Throws: Rethrows any error thrown by the handler or the underlying watch operation.
-    public func watchInt<Value: RawRepresentable<Int> & Sendable, Return: ~Copyable>(
+    public func watchInt<Value: RawRepresentable & Sendable, Return: ~Copyable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
@@ -6056,14 +6056,14 @@ extension ConfigReader {
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<Value, Never>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return where Value.RawValue: FixedWidthInteger {
         try await watchValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -6094,20 +6094,20 @@ extension ConfigReader {
     ///     produces an error if the provider returned a `nil` value or if the value was of an incorrect type.
     /// - Returns: The result produced by the handler.
     /// - Throws: Rethrows any error thrown by the handler or the underlying watch operation.
-    public func watchRequiredInt<Value: RawRepresentable<Int> & Sendable, Return: ~Copyable>(
+    public func watchRequiredInt<Value: RawRepresentable & Sendable, Return: ~Copyable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<Value, any Error>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return where Value.RawValue: FixedWidthInteger {
         try await watchRequiredValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -6142,20 +6142,20 @@ extension ConfigReader {
     ///     produces `nil` if the value is missing or can't be converted.
     /// - Returns: The result produced by the handler.
     /// - Throws: Rethrows any error thrown by the handler or the underlying watch operation.
-    public func watchIntArray<Value: RawRepresentable<Int> & Sendable, Return: ~Copyable>(
+    public func watchIntArray<Value: RawRepresentable & Sendable, Return: ~Copyable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<[Value]?, Never>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return where Value.RawValue: FixedWidthInteger {
         try await watchValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -6187,7 +6187,7 @@ extension ConfigReader {
     ///     produces the default value if the provider returned a `nil` value or conversion failed.
     /// - Returns: The result produced by the handler.
     /// - Throws: Rethrows any error thrown by the handler or the underlying watch operation.
-    public func watchIntArray<Value: RawRepresentable<Int> & Sendable, Return: ~Copyable>(
+    public func watchIntArray<Value: RawRepresentable & Sendable, Return: ~Copyable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
@@ -6195,14 +6195,14 @@ extension ConfigReader {
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<[Value], Never>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return where Value.RawValue: FixedWidthInteger {
         try await watchValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -6233,20 +6233,20 @@ extension ConfigReader {
     ///     produces an error if the provider returned a `nil` value or if the value was of an incorrect type.
     /// - Returns: The result produced by the handler.
     /// - Throws: Rethrows any error thrown by the handler or the underlying watch operation.
-    public func watchRequiredIntArray<Value: RawRepresentable<Int> & Sendable, Return: ~Copyable>(
+    public func watchRequiredIntArray<Value: RawRepresentable & Sendable, Return: ~Copyable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<[Value], any Error>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return where Value.RawValue: FixedWidthInteger {
         try await watchRequiredValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler

--- a/Sources/Configuration/ConfigReader+methods.swift.gyb
+++ b/Sources/Configuration/ConfigReader+methods.swift.gyb
@@ -365,13 +365,13 @@ extension ConfigReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> Value? {
+    ) -> Value?${int_convertible_type["whereClause"]} {
         value(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -402,14 +402,14 @@ extension ConfigReader {
         default defaultValue: Value,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> Value {
+    ) -> Value${int_convertible_type["whereClause"]} {
         value(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -438,13 +438,13 @@ extension ConfigReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) throws -> Value {
+    ) throws -> Value${int_convertible_type["whereClause"]} {
         try requiredValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -472,13 +472,13 @@ extension ConfigReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> [Value]? {
+    ) -> [Value]?${int_convertible_type["whereClause"]} {
         value(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -509,14 +509,14 @@ extension ConfigReader {
         default defaultValue: [Value],
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> [Value] {
+    ) -> [Value]${int_convertible_type["whereClause"]} {
         value(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -545,13 +545,13 @@ extension ConfigReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) throws -> [Value] {
+    ) throws -> [Value]${int_convertible_type["whereClause"]} {
         try requiredValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -909,13 +909,13 @@ extension ConfigReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> Value? {
+    ) async throws -> Value?${int_convertible_type["whereClause"]} {
         try await fetchValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -946,14 +946,14 @@ extension ConfigReader {
         default defaultValue: Value,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> Value {
+    ) async throws -> Value${int_convertible_type["whereClause"]} {
         try await fetchValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -982,13 +982,13 @@ extension ConfigReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> Value {
+    ) async throws -> Value${int_convertible_type["whereClause"]} {
         try await fetchRequiredValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -1017,13 +1017,13 @@ extension ConfigReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> [Value]? {
+    ) async throws -> [Value]?${int_convertible_type["whereClause"]} {
         try await fetchValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -1054,14 +1054,14 @@ extension ConfigReader {
         default defaultValue: [Value],
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> [Value] {
+    ) async throws -> [Value]${int_convertible_type["whereClause"]} {
         try await fetchValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -1090,13 +1090,13 @@ extension ConfigReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) async throws -> [Value] {
+    ) async throws -> [Value]${int_convertible_type["whereClause"]} {
         try await fetchRequiredValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -1556,13 +1556,13 @@ extension ConfigReader {
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<Value?, Never>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return${int_convertible_type["whereClause"]} {
         try await watchValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -1602,14 +1602,14 @@ extension ConfigReader {
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<Value, Never>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return${int_convertible_type["whereClause"]} {
         try await watchValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -1647,13 +1647,13 @@ extension ConfigReader {
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<Value, any Error>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return${int_convertible_type["whereClause"]} {
         try await watchRequiredValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -1695,13 +1695,13 @@ extension ConfigReader {
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<[Value]?, Never>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return${int_convertible_type["whereClause"]} {
         try await watchValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -1741,14 +1741,14 @@ extension ConfigReader {
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<[Value], Never>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return${int_convertible_type["whereClause"]} {
         try await watchValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler
@@ -1786,13 +1786,13 @@ extension ConfigReader {
         fileID: String = #fileID,
         line: UInt = #line,
         updatesHandler: (_ updates: ConfigUpdatesAsyncSequence<[Value], any Error>) async throws -> Return
-    ) async throws -> Return {
+    ) async throws -> Return${int_convertible_type["whereClause"]} {
         try await watchRequiredValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line,
             updatesHandler: updatesHandler

--- a/Sources/Configuration/ConfigReader.swift
+++ b/Sources/Configuration/ConfigReader.swift
@@ -109,7 +109,7 @@ import Foundation
 ///
 /// The library can automatically convert string or int configuration values to other types using the `as:` parameter.
 /// This works with:
-/// - String or Int backed enum types, as they conform to `RawRepresentable<String>` or `RawRepresentable<Int>`.
+/// - String-backed enums and enums backed by a fixed-width integer, through `RawRepresentable`.
 /// - Types that you explicitly conform to ``ExpressibleByConfigString`` or ``ExpressibleByConfigInt``.
 /// - Built-in types that already conform to ``ExpressibleByConfigString``:
 ///   - `SystemPackage.FilePath` - Converts from file paths.

--- a/Sources/Configuration/ConfigSnapshotReader+methods.swift
+++ b/Sources/Configuration/ConfigSnapshotReader+methods.swift
@@ -1695,19 +1695,19 @@ extension ConfigSnapshotReader {
     ///   - fileID: The file ID where this call originates. Used for access reporting.
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The value converted to the expected type if found and convertible, otherwise `nil`.
-    public func int<Value: RawRepresentable<Int>>(
+    public func int<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> Value? {
+    ) -> Value? where Value.RawValue: FixedWidthInteger {
         value(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1731,21 +1731,21 @@ extension ConfigSnapshotReader {
     ///   - fileID: The file ID where this call originates. Used for access reporting.
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config value if found and convertible, otherwise the default value.
-    public func int<Value: RawRepresentable<Int>>(
+    public func int<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         default defaultValue: Value,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> Value {
+    ) -> Value where Value.RawValue: FixedWidthInteger {
         value(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1768,19 +1768,19 @@ extension ConfigSnapshotReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config value converted to the expected type.
     /// - Throws: An error if the value is missing or can't be converted to the expected type.
-    public func requiredInt<Value: RawRepresentable<Int>>(
+    public func requiredInt<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) throws -> Value {
+    ) throws -> Value where Value.RawValue: FixedWidthInteger {
         try requiredValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1802,19 +1802,19 @@ extension ConfigSnapshotReader {
     ///   - fileID: The file ID where this call originates. Used for access reporting.
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: An array of values converted to the expected type if found and convertible, otherwise `nil`.
-    public func intArray<Value: RawRepresentable<Int>>(
+    public func intArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> [Value]? {
+    ) -> [Value]? where Value.RawValue: FixedWidthInteger {
         value(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1838,21 +1838,21 @@ extension ConfigSnapshotReader {
     ///   - fileID: The file ID where this call originates. Used for access reporting.
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config array if found and convertible, otherwise the default array.
-    public func intArray<Value: RawRepresentable<Int>>(
+    public func intArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         default defaultValue: [Value],
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> [Value] {
+    ) -> [Value] where Value.RawValue: FixedWidthInteger {
         value(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )
@@ -1875,19 +1875,19 @@ extension ConfigSnapshotReader {
     ///   - line: The line number where this call originates. Used for access reporting.
     /// - Returns: The config array converted to the expected type.
     /// - Throws: An error if the value is missing or can't be converted to the expected type.
-    public func requiredIntArray<Value: RawRepresentable<Int>>(
+    public func requiredIntArray<Value: RawRepresentable>(
         forKey key: ConfigKey,
         as type: Value.Type = Value.self,
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) throws -> [Value] {
+    ) throws -> [Value] where Value.RawValue: FixedWidthInteger {
         try requiredValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { try uncast($0, key: key) },
             fileID: fileID,
             line: line
         )

--- a/Sources/Configuration/ConfigSnapshotReader+methods.swift.gyb
+++ b/Sources/Configuration/ConfigSnapshotReader+methods.swift.gyb
@@ -365,13 +365,13 @@ extension ConfigSnapshotReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> Value? {
+    ) -> Value?${int_convertible_type["whereClause"]} {
         value(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -402,14 +402,14 @@ extension ConfigSnapshotReader {
         default defaultValue: Value,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> Value {
+    ) -> Value${int_convertible_type["whereClause"]} {
         value(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -438,13 +438,13 @@ extension ConfigSnapshotReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) throws -> Value {
+    ) throws -> Value${int_convertible_type["whereClause"]} {
         try requiredValue(
             forKey: key,
             type: .int,
             isSecret: isSecret,
             unwrap: { try cast($0.asInt, type: Value.self, key: key) },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -472,13 +472,13 @@ extension ConfigSnapshotReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> [Value]? {
+    ) -> [Value]?${int_convertible_type["whereClause"]} {
         value(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -509,14 +509,14 @@ extension ConfigSnapshotReader {
         default defaultValue: [Value],
         fileID: String = #fileID,
         line: UInt = #line
-    ) -> [Value] {
+    ) -> [Value]${int_convertible_type["whereClause"]} {
         value(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             default: defaultValue,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )
@@ -545,13 +545,13 @@ extension ConfigSnapshotReader {
         isSecret: Bool = false,
         fileID: String = #fileID,
         line: UInt = #line
-    ) throws -> [Value] {
+    ) throws -> [Value]${int_convertible_type["whereClause"]} {
         try requiredValue(
             forKey: key,
             type: .intArray,
             isSecret: isSecret,
             unwrap: { try $0.asIntArray.map { try cast($0, type: Value.self, key: key) } },
-            wrap: { uncast($0) },
+            wrap: { ${int_convertible_type["wrap"]} },
             fileID: fileID,
             line: line
         )

--- a/Sources/Configuration/ConfigSnapshotReader.swift
+++ b/Sources/Configuration/ConfigSnapshotReader.swift
@@ -319,7 +319,7 @@ extension ConfigSnapshotReader {
         type: ConfigType,
         isSecret: Bool,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) -> Value? {
@@ -355,7 +355,7 @@ extension ConfigSnapshotReader {
         isSecret: Bool,
         default defaultValue: Value,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) -> Value {
@@ -391,7 +391,7 @@ extension ConfigSnapshotReader {
         type: ConfigType,
         isSecret: Bool,
         unwrap: (ConfigContent) throws -> Value,
-        wrap: (Value) -> ConfigContent,
+        wrap: (Value) throws -> ConfigContent,
         fileID: String,
         line: UInt
     ) throws -> Value {
@@ -506,7 +506,7 @@ extension ConfigSnapshotReader {
         return typedValue
     }
 
-    /// Casts an integer value to a `RawRepresentable` type with an `Int` raw value.
+    /// Casts an integer value to a `RawRepresentable` type with an integer raw value.
     ///
     /// - Parameters:
     ///   - int: The integer to cast.
@@ -514,12 +514,14 @@ extension ConfigSnapshotReader {
     ///   - key: The config key for error reporting.
     /// - Returns: The cast value.
     /// - Throws: A `ConfigError` if the integer can't be cast to the type.
-    internal func cast<Value: RawRepresentable<Int>>(
+    internal func cast<Value: RawRepresentable>(
         _ int: Int,
         type: Value.Type,
         key: ConfigKey
-    ) throws -> Value {
-        guard let typedValue = Value.init(rawValue: int) else {
+    ) throws -> Value where Value.RawValue: FixedWidthInteger {
+        guard let rawValue = Value.RawValue(exactly: int),
+            let typedValue = Value.init(rawValue: rawValue)
+        else {
             throw ConfigError.configValueFailedToCast(name: keyPrefix.appending(key).description, type: "\(type)")
         }
         return typedValue
@@ -545,23 +547,44 @@ extension ConfigSnapshotReader {
         .intArray(values.map(\.configInt))
     }
 
-    /// Converts a `RawRepresentable` value with an `Int` raw value to content.
+    /// Converts a `RawRepresentable` value with an integer raw value to content.
     ///
-    /// - Parameter value: The value to convert.
+    /// - Parameters:
+    ///   - value: The value to convert.
+    ///   - key: The config key for error context.
     /// - Returns: The config content.
-    internal func uncast<Value: RawRepresentable<Int>>(
-        _ value: Value
-    ) -> ConfigContent {
-        .int(value.rawValue)
+    /// - Throws: A `ConfigError` if the raw value can't be represented as an `Int`.
+    internal func uncast<Value: RawRepresentable>(
+        _ value: Value,
+        key: ConfigKey
+    ) throws -> ConfigContent where Value.RawValue: FixedWidthInteger {
+        guard let int = Int(exactly: value.rawValue) else {
+            throw ConfigError.configValueFailedToCast(name: keyPrefix.appending(key).description, type: "Int")
+        }
+        return .int(int)
     }
 
-    /// Converts an array of `RawRepresentable` values with `Int` raw values to content.
+    /// Converts an array of `RawRepresentable` values with integer raw values to content.
     ///
-    /// - Parameter values: The values to convert.
+    /// - Parameters:
+    ///   - values: The values to convert.
+    ///   - key: The config key for error context.
     /// - Returns: The config content.
-    internal func uncast<Value: RawRepresentable<Int>>(
-        _ values: [Value]
-    ) -> ConfigContent {
-        .intArray(values.map(\.rawValue))
+    /// - Throws: A `ConfigError` if a raw value can't be represented as an `Int`.
+    internal func uncast<Value: RawRepresentable>(
+        _ values: [Value],
+        key: ConfigKey
+    ) throws -> ConfigContent where Value.RawValue: FixedWidthInteger {
+        .intArray(
+            try values.map { value in
+                guard let int = Int(exactly: value.rawValue) else {
+                    throw ConfigError.configValueFailedToCast(
+                        name: keyPrefix.appending(key).description,
+                        type: "Int"
+                    )
+                }
+                return int
+            }
+        )
     }
 }

--- a/Sources/Configuration/Documentation.docc/Guides/Choosing-reader-methods.md
+++ b/Sources/Configuration/Documentation.docc/Guides/Choosing-reader-methods.md
@@ -301,9 +301,10 @@ This works with:
 
 - `Swift.Duration`: Converts from an integer value to a duration measured in seconds.
 
-**Int-backed enums:**
+**Integer-backed enums:**
 
-- Types that conform to `RawRepresentable<Int>`.
+- Types that conform to `RawRepresentable` with a `FixedWidthInteger` raw value.
+  Conversion is exact, so values outside the raw type's range are rejected.
 
 **Custom types:**
 
@@ -313,8 +314,8 @@ This works with:
 // Built-in type conversion
 let timeout = config.int(forKey: "api.timeout", as: Duration.self)
 
-// Int-backed enum conversion (RawRepresentable<Int>)
-enum LogLevel: Int {
+// Integer-backed enum conversion
+enum LogLevel: UInt8 {
     case error = 1
     case warning = 2
 }

--- a/Sources/Configuration/ExpressibleByConfigInt.swift
+++ b/Sources/Configuration/ExpressibleByConfigInt.swift
@@ -19,7 +19,8 @@
 ///
 /// > Tip: If your type is an integer-based enum, you don't need to explicitly conform it to
 /// > ``ExpressibleByConfigInt``, as the same conversions work for types
-/// > that conform to `RawRepresentable` with an `Int` raw value automatically.
+/// > that conform to `RawRepresentable` with a `FixedWidthInteger` raw value automatically.
+/// > Conversion is exact, so configuration values outside the raw type's range aren't accepted.
 ///
 /// ## Custom types
 ///

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsFetch4.swift
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsFetch4.swift
@@ -26,6 +26,7 @@ struct ConfigReaderMethodTestsFetch4 {
 
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
@@ -132,6 +133,54 @@ struct ConfigReaderMethodTestsFetch4 {
             // Required - failing
             await #expect(throws: TestProvider.TestError.self) {
                 try await config.fetchRequiredInt(forKey: "failure", as: TestIntEnum.self)
+            }
+        }
+        do {
+            // Optional - success
+            #expect(try await config.fetchInt(forKey: "uint8Enum", as: TestUInt8Enum.self) == Defaults.uint8Enum)
+
+            // Optional - missing
+            #expect(try await config.fetchInt(forKey: "absentUInt8Enum", as: TestUInt8Enum.self) == nil)
+
+            // Optional - failing
+            await #expect(throws: TestProvider.TestError.self) {
+                try await config.fetchInt(forKey: "failure", as: TestUInt8Enum.self)
+            }
+
+            // Defaulted - success
+            #expect(
+                try await config.fetchInt(forKey: "uint8Enum", as: TestUInt8Enum.self, default: Defaults.otherUInt8Enum)
+                    == Defaults.uint8Enum
+            )
+
+            // Defaulted - missing
+            #expect(
+                try await config.fetchInt(
+                    forKey: "absentUInt8Enum",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8Enum
+                ) == Defaults.otherUInt8Enum
+            )
+
+            // Defaulted - failing
+            await #expect(throws: TestProvider.TestError.self) {
+                try await config.fetchInt(forKey: "failure", as: TestUInt8Enum.self, default: Defaults.otherUInt8Enum)
+            }
+
+            // Required - success
+            #expect(
+                try await config.fetchRequiredInt(forKey: "uint8Enum", as: TestUInt8Enum.self) == Defaults.uint8Enum
+            )
+
+            // Required - missing
+            let error1 = await #expect(throws: ConfigError.self) {
+                try await config.fetchRequiredInt(forKey: "absentUInt8Enum", as: TestUInt8Enum.self)
+            }
+            #expect(error1 == .missingRequiredConfigValue(AbsoluteConfigKey(["absentUInt8Enum"])))
+
+            // Required - failing
+            await #expect(throws: TestProvider.TestError.self) {
+                try await config.fetchRequiredInt(forKey: "failure", as: TestUInt8Enum.self)
             }
         }
     }

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsFetch4.swift.gyb
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsFetch4.swift.gyb
@@ -24,17 +24,18 @@ struct ConfigReaderMethodTestsFetch4 {
     
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
     @Test func fetch() async throws {
         let config = ConfigReaderTests.config
         
-        % for int_convertible_type in int_convertible_types:
+        % for int_convertible_type in int_convertible_test_types:
         % suffix = "Int"
         % test_type = int_convertible_type["testType"]
         % test_suffix = int_convertible_type["testSuffix"]
-        % lower_test_suffix = lower_first(test_suffix)
+        % lower_test_suffix = int_convertible_type.get("lowerTestSuffix", lower_first(test_suffix))
         do {
             // Optional - success
             #expect(try await config.fetch${suffix}(forKey: "${lower_test_suffix}", as: ${test_type}.self) == Defaults.${lower_test_suffix})

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsFetch5.swift
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsFetch5.swift
@@ -26,6 +26,7 @@ struct ConfigReaderMethodTestsFetch5 {
 
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
@@ -149,6 +150,65 @@ struct ConfigReaderMethodTestsFetch5 {
             // Required - failing
             await #expect(throws: TestProvider.TestError.self) {
                 try await config.fetchRequiredIntArray(forKey: "failure", as: TestIntEnum.self)
+            }
+        }
+        do {
+            // Optional - success
+            #expect(
+                try await config.fetchIntArray(forKey: "uint8EnumArray", as: TestUInt8Enum.self)
+                    == Defaults.uint8EnumArray
+            )
+
+            // Optional - missing
+            #expect(try await config.fetchIntArray(forKey: "absentUInt8EnumArray", as: TestUInt8Enum.self) == nil)
+
+            // Optional - failing
+            await #expect(throws: TestProvider.TestError.self) {
+                try await config.fetchIntArray(forKey: "failure", as: TestUInt8Enum.self)
+            }
+
+            // Defaulted - success
+            #expect(
+                try await config.fetchIntArray(
+                    forKey: "uint8EnumArray",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8EnumArray
+                ) == Defaults.uint8EnumArray
+            )
+
+            // Defaulted - missing
+            #expect(
+                try await config.fetchIntArray(
+                    forKey: "absentUInt8EnumArray",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8EnumArray
+                ) == Defaults.otherUInt8EnumArray
+            )
+
+            // Defaulted - failing
+            await #expect(throws: TestProvider.TestError.self) {
+                try await config.fetchIntArray(
+                    forKey: "failure",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8EnumArray
+                )
+            }
+
+            // Required - success
+            #expect(
+                try await config.fetchRequiredIntArray(forKey: "uint8EnumArray", as: TestUInt8Enum.self)
+                    == Defaults.uint8EnumArray
+            )
+
+            // Required - missing
+            let error1 = await #expect(throws: ConfigError.self) {
+                try await config.fetchRequiredIntArray(forKey: "absentUInt8EnumArray", as: TestUInt8Enum.self)
+            }
+            #expect(error1 == .missingRequiredConfigValue(AbsoluteConfigKey(["absentUInt8EnumArray"])))
+
+            // Required - failing
+            await #expect(throws: TestProvider.TestError.self) {
+                try await config.fetchRequiredIntArray(forKey: "failure", as: TestUInt8Enum.self)
             }
         }
     }

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsFetch5.swift.gyb
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsFetch5.swift.gyb
@@ -24,17 +24,18 @@ struct ConfigReaderMethodTestsFetch5 {
     
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
     @Test func fetch() async throws {
         let config = ConfigReaderTests.config
         
-        % for int_convertible_type in int_convertible_types:
+        % for int_convertible_type in int_convertible_test_types:
         % suffix = "IntArray"
         % test_type = int_convertible_type["testType"]
         % test_suffix = int_convertible_type["testSuffix"] + "Array"
-        % lower_test_suffix = lower_first(test_suffix)
+        % lower_test_suffix = int_convertible_type.get("lowerTestSuffix", lower_first(int_convertible_type["testSuffix"])) + "Array"
         do {
             // Optional - success
             #expect(try await config.fetch${suffix}(forKey: "${lower_test_suffix}", as: ${test_type}.self) == Defaults.${lower_test_suffix})

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsGet4.swift
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsGet4.swift
@@ -26,6 +26,7 @@ struct ConfigReaderMethodTestsGet4 {
 
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
@@ -118,6 +119,48 @@ struct ConfigReaderMethodTestsGet4 {
             // Required - failing
             #expect(throws: TestProvider.TestError.self) {
                 try config.requiredInt(forKey: "failure", as: TestIntEnum.self)
+            }
+        }
+        do {
+            // Optional - success
+            #expect(config.int(forKey: "uint8Enum", as: TestUInt8Enum.self) == Defaults.uint8Enum)
+
+            // Optional - missing
+            #expect(config.int(forKey: "absentUInt8Enum", as: TestUInt8Enum.self) == nil)
+
+            // Optional - failing
+            #expect(config.int(forKey: "failure", as: TestUInt8Enum.self) == nil)
+
+            // Defaulted - success
+            #expect(
+                config.int(forKey: "uint8Enum", as: TestUInt8Enum.self, default: Defaults.otherUInt8Enum)
+                    == Defaults.uint8Enum
+            )
+
+            // Defaulted - missing
+            #expect(
+                config.int(forKey: "absentUInt8Enum", as: TestUInt8Enum.self, default: Defaults.otherUInt8Enum)
+                    == Defaults.otherUInt8Enum
+            )
+
+            // Defaulted - failing
+            #expect(
+                config.int(forKey: "failure", as: TestUInt8Enum.self, default: Defaults.otherUInt8Enum)
+                    == Defaults.otherUInt8Enum
+            )
+
+            // Required - success
+            #expect(try config.requiredInt(forKey: "uint8Enum", as: TestUInt8Enum.self) == Defaults.uint8Enum)
+
+            // Required - missing
+            let error1 = #expect(throws: ConfigError.self) {
+                try config.requiredInt(forKey: "absentUInt8Enum", as: TestUInt8Enum.self)
+            }
+            #expect(error1 == .missingRequiredConfigValue(AbsoluteConfigKey(["absentUInt8Enum"])))
+
+            // Required - failing
+            #expect(throws: TestProvider.TestError.self) {
+                try config.requiredInt(forKey: "failure", as: TestUInt8Enum.self)
             }
         }
     }

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsGet4.swift.gyb
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsGet4.swift.gyb
@@ -24,16 +24,17 @@ struct ConfigReaderMethodTestsGet4 {
     
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
     @Test func get() async throws {
         let config = ConfigReaderTests.config
         
-        % for int_convertible_type in int_convertible_types:
+        % for int_convertible_type in int_convertible_test_types:
         % test_type = int_convertible_type["testType"]
         % test_suffix = int_convertible_type["testSuffix"]
-        % lower_test_suffix = lower_first(test_suffix)
+        % lower_test_suffix = int_convertible_type.get("lowerTestSuffix", lower_first(test_suffix))
         do {
             // Optional - success
             #expect(config.int(forKey: "${lower_test_suffix}", as: ${test_type}.self) == Defaults.${lower_test_suffix})

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsGet5.swift
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsGet5.swift
@@ -26,6 +26,7 @@ struct ConfigReaderMethodTestsGet5 {
 
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
@@ -129,6 +130,53 @@ struct ConfigReaderMethodTestsGet5 {
             // Required - failing
             #expect(throws: TestProvider.TestError.self) {
                 try config.requiredIntArray(forKey: "failure", as: TestIntEnum.self)
+            }
+        }
+        do {
+            // Optional - success
+            #expect(config.intArray(forKey: "uint8EnumArray", as: TestUInt8Enum.self) == Defaults.uint8EnumArray)
+
+            // Optional - missing
+            #expect(config.intArray(forKey: "absentUInt8EnumArray", as: TestUInt8Enum.self) == nil)
+
+            // Optional - failing
+            #expect(config.intArray(forKey: "failure", as: TestUInt8Enum.self) == nil)
+
+            // Defaulted - success
+            #expect(
+                config.intArray(forKey: "uint8EnumArray", as: TestUInt8Enum.self, default: Defaults.otherUInt8EnumArray)
+                    == Defaults.uint8EnumArray
+            )
+
+            // Defaulted - missing
+            #expect(
+                config.intArray(
+                    forKey: "absentUInt8EnumArray",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8EnumArray
+                ) == Defaults.otherUInt8EnumArray
+            )
+
+            // Defaulted - failing
+            #expect(
+                config.intArray(forKey: "failure", as: TestUInt8Enum.self, default: Defaults.otherUInt8EnumArray)
+                    == Defaults.otherUInt8EnumArray
+            )
+
+            // Required - success
+            #expect(
+                try config.requiredIntArray(forKey: "uint8EnumArray", as: TestUInt8Enum.self) == Defaults.uint8EnumArray
+            )
+
+            // Required - missing
+            let error1 = #expect(throws: ConfigError.self) {
+                try config.requiredIntArray(forKey: "absentUInt8EnumArray", as: TestUInt8Enum.self)
+            }
+            #expect(error1 == .missingRequiredConfigValue(AbsoluteConfigKey(["absentUInt8EnumArray"])))
+
+            // Required - failing
+            #expect(throws: TestProvider.TestError.self) {
+                try config.requiredIntArray(forKey: "failure", as: TestUInt8Enum.self)
             }
         }
     }

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsGet5.swift.gyb
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsGet5.swift.gyb
@@ -24,16 +24,17 @@ struct ConfigReaderMethodTestsGet5 {
     
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
     @Test func get() async throws {
         let config = ConfigReaderTests.config
         
-        % for int_convertible_type in int_convertible_types:
+        % for int_convertible_type in int_convertible_test_types:
         % test_type = int_convertible_type["testType"]
         % test_suffix = int_convertible_type["testSuffix"] + "Array"
-        % lower_test_suffix = lower_first(test_suffix)
+        % lower_test_suffix = int_convertible_type.get("lowerTestSuffix", lower_first(int_convertible_type["testSuffix"])) + "Array"
         do {
             // Optional - success
             #expect(config.intArray(forKey: "${lower_test_suffix}", as: ${test_type}.self) == Defaults.${lower_test_suffix})

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsWatch4.swift
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsWatch4.swift
@@ -28,6 +28,7 @@ struct ConfigReaderMethodTestsWatch4 {
 
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
@@ -185,6 +186,79 @@ struct ConfigReaderMethodTestsWatch4 {
             // Required - failing
             await #expect(throws: TestProvider.TestError.self) {
                 try await config.watchRequiredInt(forKey: "failure", as: TestIntEnum.self, updatesHandler: awaitFirst)
+            }
+        }
+        do {
+            // Optional - success
+            #expect(
+                try await config.watchInt(forKey: "uint8Enum", as: TestUInt8Enum.self, updatesHandler: awaitFirst)
+                    == Defaults.uint8Enum
+            )
+
+            // Optional - missing
+            #expect(
+                try await config.watchInt(forKey: "absentUInt8Enum", as: TestUInt8Enum.self, updatesHandler: awaitFirst)
+                    == .some(nil)
+            )
+
+            // Optional - failing
+            #expect(
+                try await config.watchInt(forKey: "failure", as: TestUInt8Enum.self, updatesHandler: awaitFirst)
+                    == .some(nil)
+            )
+
+            // Defaulted - success
+            #expect(
+                try await config.watchInt(
+                    forKey: "uint8Enum",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8Enum,
+                    updatesHandler: awaitFirst
+                ) == Defaults.uint8Enum
+            )
+
+            // Defaulted - missing
+            #expect(
+                try await config.watchInt(
+                    forKey: "absentUInt8Enum",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8Enum,
+                    updatesHandler: awaitFirst
+                ) == Defaults.otherUInt8Enum
+            )
+
+            // Defaulted - failing
+            #expect(
+                try await config.watchInt(
+                    forKey: "failure",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8Enum,
+                    updatesHandler: awaitFirst
+                ) == Defaults.otherUInt8Enum
+            )
+
+            // Required - success
+            #expect(
+                try await config.watchRequiredInt(
+                    forKey: "uint8Enum",
+                    as: TestUInt8Enum.self,
+                    updatesHandler: awaitFirst
+                ) == Defaults.uint8Enum
+            )
+
+            // Required - missing
+            let error1 = await #expect(throws: ConfigError.self) {
+                try await config.watchRequiredInt(
+                    forKey: "absentUInt8Enum",
+                    as: TestUInt8Enum.self,
+                    updatesHandler: awaitFirst
+                )
+            }
+            #expect(error1 == .missingRequiredConfigValue(AbsoluteConfigKey(["absentUInt8Enum"])))
+
+            // Required - failing
+            await #expect(throws: TestProvider.TestError.self) {
+                try await config.watchRequiredInt(forKey: "failure", as: TestUInt8Enum.self, updatesHandler: awaitFirst)
             }
         }
     }

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsWatch4.swift.gyb
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsWatch4.swift.gyb
@@ -25,17 +25,18 @@ struct ConfigReaderMethodTestsWatch4 {
     
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
     @Test func watch() async throws {
         let config = ConfigReaderTests.config
         
-        % for int_convertible_type in int_convertible_types:
+        % for int_convertible_type in int_convertible_test_types:
         % suffix = "Int"
         % test_type = int_convertible_type["testType"]
         % test_suffix = int_convertible_type["testSuffix"]
-        % lower_test_suffix = lower_first(test_suffix)
+        % lower_test_suffix = int_convertible_type.get("lowerTestSuffix", lower_first(test_suffix))
         do {
             // Optional - success
             #expect(try await config.watch${suffix}(forKey: "${lower_test_suffix}", as: ${test_type}.self, updatesHandler: awaitFirst) == Defaults.${lower_test_suffix})

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsWatch5.swift
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsWatch5.swift
@@ -28,6 +28,7 @@ struct ConfigReaderMethodTestsWatch5 {
 
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
@@ -196,6 +197,89 @@ struct ConfigReaderMethodTestsWatch5 {
                 try await config.watchRequiredIntArray(
                     forKey: "failure",
                     as: TestIntEnum.self,
+                    updatesHandler: awaitFirst
+                )
+            }
+        }
+        do {
+            // Optional - success
+            #expect(
+                try await config.watchIntArray(
+                    forKey: "uint8EnumArray",
+                    as: TestUInt8Enum.self,
+                    updatesHandler: awaitFirst
+                ) == Defaults.uint8EnumArray
+            )
+
+            // Optional - missing
+            #expect(
+                try await config.watchIntArray(
+                    forKey: "absentUInt8EnumArray",
+                    as: TestUInt8Enum.self,
+                    updatesHandler: awaitFirst
+                ) == .some(nil)
+            )
+
+            // Optional - failing
+            #expect(
+                try await config.watchIntArray(forKey: "failure", as: TestUInt8Enum.self, updatesHandler: awaitFirst)
+                    == .some(nil)
+            )
+
+            // Defaulted - success
+            #expect(
+                try await config.watchIntArray(
+                    forKey: "uint8EnumArray",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8EnumArray,
+                    updatesHandler: awaitFirst
+                ) == Defaults.uint8EnumArray
+            )
+
+            // Defaulted - missing
+            #expect(
+                try await config.watchIntArray(
+                    forKey: "absentUInt8EnumArray",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8EnumArray,
+                    updatesHandler: awaitFirst
+                ) == Defaults.otherUInt8EnumArray
+            )
+
+            // Defaulted - failing
+            #expect(
+                try await config.watchIntArray(
+                    forKey: "failure",
+                    as: TestUInt8Enum.self,
+                    default: Defaults.otherUInt8EnumArray,
+                    updatesHandler: awaitFirst
+                ) == Defaults.otherUInt8EnumArray
+            )
+
+            // Required - success
+            #expect(
+                try await config.watchRequiredIntArray(
+                    forKey: "uint8EnumArray",
+                    as: TestUInt8Enum.self,
+                    updatesHandler: awaitFirst
+                ) == Defaults.uint8EnumArray
+            )
+
+            // Required - missing
+            let error1 = await #expect(throws: ConfigError.self) {
+                try await config.watchRequiredIntArray(
+                    forKey: "absentUInt8EnumArray",
+                    as: TestUInt8Enum.self,
+                    updatesHandler: awaitFirst
+                )
+            }
+            #expect(error1 == .missingRequiredConfigValue(AbsoluteConfigKey(["absentUInt8EnumArray"])))
+
+            // Required - failing
+            await #expect(throws: TestProvider.TestError.self) {
+                try await config.watchRequiredIntArray(
+                    forKey: "failure",
+                    as: TestUInt8Enum.self,
                     updatesHandler: awaitFirst
                 )
             }

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsWatch5.swift.gyb
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderMethodTestsWatch5.swift.gyb
@@ -25,17 +25,18 @@ struct ConfigReaderMethodTestsWatch5 {
     
     typealias Defaults = ConfigReaderTests.Defaults
     typealias TestIntEnum = ConfigReaderTests.TestIntEnum
+    typealias TestUInt8Enum = ConfigReaderTests.TestUInt8Enum
     typealias TestIntConvertible = ConfigReaderTests.TestIntConvertible
 
     @available(Configuration 1.0, *)
     @Test func watch() async throws {
         let config = ConfigReaderTests.config
         
-        % for int_convertible_type in int_convertible_types:
+        % for int_convertible_type in int_convertible_test_types:
         % suffix = "IntArray"
         % test_type = int_convertible_type["testType"]
         % test_suffix = int_convertible_type["testSuffix"] + "Array"
-        % lower_test_suffix = lower_first(test_suffix)
+        % lower_test_suffix = int_convertible_type.get("lowerTestSuffix", lower_first(int_convertible_type["testSuffix"])) + "Array"
         do {
             // Optional - success
             #expect(try await config.watch${suffix}(forKey: "${lower_test_suffix}", as: ${test_type}.self, updatesHandler: awaitFirst) == Defaults.${lower_test_suffix})

--- a/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderTests.swift
+++ b/Tests/ConfigurationTests/ConfigReaderTests/ConfigReaderTests.swift
@@ -81,6 +81,11 @@ struct ConfigReaderTests {
         case one
     }
 
+    enum TestUInt8Enum: UInt8, Equatable {
+        case zero
+        case one
+    }
+
     struct TestIntConvertible: ExpressibleByConfigInt, Equatable {
         var configInt: Int
         var description: String { "\(configInt)" }
@@ -129,10 +134,14 @@ struct ConfigReaderTests {
         static var otherStringConvertibleArray: [TestStringConvertible] { [.hello, .world, .hello] }
         static var intEnum: TestIntEnum { .zero }
         static var otherIntEnum: TestIntEnum { .one }
+        static var uint8Enum: TestUInt8Enum { .zero }
+        static var otherUInt8Enum: TestUInt8Enum { .one }
         static var intConvertible: TestIntConvertible { .zero }
         static var otherIntConvertible: TestIntConvertible { .zero }
         static var intEnumArray: [TestIntEnum] { [.zero, .one] }
         static var otherIntEnumArray: [TestIntEnum] { [.zero, .one, .zero] }
+        static var uint8EnumArray: [TestUInt8Enum] { [.zero, .one] }
+        static var otherUInt8EnumArray: [TestUInt8Enum] { [.zero, .one, .zero] }
         static var intConvertibleArray: [TestIntConvertible] { [.zero, .one] }
         static var otherIntConvertibleArray: [TestIntConvertible] { [.zero, .one, .zero] }
     }
@@ -158,8 +167,12 @@ struct ConfigReaderTests {
                 ConfigValue(Defaults.stringConvertibleArray.map(\.description), isSecret: false)
             ),
             "intEnum": .success(ConfigValue(Defaults.intEnum.rawValue, isSecret: false)),
+            "uint8Enum": .success(ConfigValue(Int(Defaults.uint8Enum.rawValue), isSecret: false)),
             "intConvertible": .success(ConfigValue(Defaults.intConvertible.configInt, isSecret: false)),
             "intEnumArray": .success(ConfigValue(Defaults.intEnumArray.map(\.rawValue), isSecret: false)),
+            "uint8EnumArray": .success(
+                ConfigValue(Defaults.uint8EnumArray.map { Int($0.rawValue) }, isSecret: false)
+            ),
             "intConvertibleArray": .success(
                 ConfigValue(Defaults.intConvertibleArray.map(\.configInt), isSecret: false)
             ),

--- a/Tests/ConfigurationTests/ConfigReaderTests/IntegerRawRepresentableTests.swift
+++ b/Tests/ConfigurationTests/ConfigReaderTests/IntegerRawRepresentableTests.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftConfiguration open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftConfiguration project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftConfiguration project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import ConfigurationTestingInternal
+import Testing
+@testable import Configuration
+
+struct IntegerRawRepresentableTests {
+    private enum UnsignedCode: UInt8, Equatable {
+        case ready = 1
+    }
+
+    private enum SignedCode: Int8, Equatable {
+        case negative = -1
+    }
+
+    private enum IntCode: Int, Equatable {
+        case ready = 1
+    }
+
+    private enum WideCode: UInt64, Equatable {
+        case maximum = 18_446_744_073_709_551_615
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func exactIntegerConversion() throws {
+        let config = ConfigReader(
+            provider: InMemoryProvider(
+                values: [
+                    "unsigned.ready": ConfigValue(1, isSecret: false),
+                    "unsigned.negative": ConfigValue(-1, isSecret: false),
+                    "unsigned.overflow": ConfigValue(256, isSecret: false),
+                    "unsigned.unknown": ConfigValue(2, isSecret: false),
+                    "unsigned.array": ConfigValue([1], isSecret: false),
+                    "unsigned.arrayOverflow": ConfigValue([1, 256], isSecret: false),
+                    "signed.negative": ConfigValue(-1, isSecret: false),
+                    "int.ready": ConfigValue(1, isSecret: false),
+                ]
+            )
+        )
+
+        #expect(config.int(forKey: "unsigned.ready", as: UnsignedCode.self) == .ready)
+        #expect(config.int(forKey: "unsigned.negative", as: UnsignedCode.self) == nil)
+        #expect(config.int(forKey: "unsigned.overflow", as: UnsignedCode.self) == nil)
+        #expect(config.int(forKey: "unsigned.unknown", as: UnsignedCode.self) == nil)
+        #expect(config.intArray(forKey: "unsigned.array", as: UnsignedCode.self) == [.ready])
+        #expect(config.intArray(forKey: "unsigned.arrayOverflow", as: UnsignedCode.self) == nil)
+        #expect(config.int(forKey: "signed.negative", as: SignedCode.self) == .negative)
+        #expect(config.int(forKey: "int.ready", as: IntCode.self) == .ready)
+
+        let error = #expect(throws: ConfigError.self) {
+            try config.requiredInt(forKey: "unsigned.negative", as: UnsignedCode.self)
+        }
+        #expect(
+            error
+                == .configValueFailedToCast(
+                    name: "unsigned.negative",
+                    type: "\(UnsignedCode.self)"
+                )
+        )
+
+        let snapshot = config.snapshot()
+        #expect(snapshot.int(forKey: "unsigned.ready", as: UnsignedCode.self) == .ready)
+        #expect(snapshot.int(forKey: "unsigned.overflow", as: UnsignedCode.self) == nil)
+        #expect(snapshot.intArray(forKey: "unsigned.array", as: UnsignedCode.self) == [.ready])
+        #expect(snapshot.intArray(forKey: "unsigned.arrayOverflow", as: UnsignedCode.self) == nil)
+        #expect(snapshot.int(forKey: "signed.negative", as: SignedCode.self) == .negative)
+        #expect(snapshot.int(forKey: "int.ready", as: IntCode.self) == .ready)
+    }
+
+    @available(Configuration 1.0, *)
+    @Test func unrepresentableDefaultsDoNotTrap() throws {
+        let accessReporter = TestAccessReporter()
+        let config = ConfigReader(
+            provider: InMemoryProvider(values: [:]),
+            accessReporter: accessReporter
+        )
+
+        #expect(config.int(forKey: "wide", as: WideCode.self, default: .maximum) == .maximum)
+        #expect(config.intArray(forKey: "wideArray", as: WideCode.self, default: [.maximum]) == [.maximum])
+
+        let events = accessReporter.events
+        try #require(events.count == 2)
+
+        for (event, key) in zip(events, ["wide", "wideArray"]) {
+            let error = #expect(throws: ConfigError.self) {
+                try event.result.get()
+            }
+            #expect(error == .configValueFailedToCast(name: key, type: "Int"))
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Integer reader overloads only accepted RawRepresentable<Int>, which
prevented enums backed by other integer types such as UInt8 from using
the automatic conversion APIs.

### Modifications

- Generalize generated reader and snapshot overloads to RawRepresentable
  types whose RawValue conforms to FixedWidthInteger.
- Use exact conversions in both directions so out-of-range values fail
  instead of truncating.
- Make internal wrapping throwing so defaults that cannot fit in Int
  produce an access-reporting conversion error rather than trapping.
- Add signed, unsigned, scalar, array, snapshot, get, fetch, and watch
  coverage, and update the public documentation.

### Result

Integer-backed enums work when their values are exactly representable,
while invalid and out-of-range values are rejected and existing
Int-backed behavior is preserved.

### Test Plan

- swift test --enable-all-traits
- swift format lint --strict --recursive Sources Tests
- Regenerated every gyb output and confirmed byte-identical results
- git diff --check

## Review questions

- Is `FixedWidthInteger` the intended constraint, or would the project prefer `BinaryInteger`?
- Is recording an access-reporting conversion failure while preserving a nonthrowing default return the preferred behavior for raw values above `Int.max`?

Fixes #205